### PR TITLE
Add API Table component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 .env*
+.idea
 
 # debug
 npm-debug.log*

--- a/components/presenters/ApiTable/ApiTable.stories.tsx
+++ b/components/presenters/ApiTable/ApiTable.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { ApiTable } from './ApiTable'
+import { ApiTableDefaultValue } from './ApiTableDefaultValue'
+import { ApiTableDescription } from './ApiTableDescription'
+import { ApiTableItem } from './ApiTableItem'
+
+const stories = storiesOf('API Table', module)
+
+stories.add('Default', () => (
+  <ApiTable>
+    <ApiTableItem isRequired name="startDate" type="Date">
+      <ApiTableDefaultValue />
+      <ApiTableDescription>The start date of the event.</ApiTableDescription>
+    </ApiTableItem>
+    <ApiTableItem name="endDate" type="Date | null">
+      <ApiTableDefaultValue>null</ApiTableDefaultValue>
+      <ApiTableDescription>The end date of the event.</ApiTableDescription>
+    </ApiTableItem>
+  </ApiTable>
+))

--- a/components/presenters/ApiTable/ApiTable.stories.tsx
+++ b/components/presenters/ApiTable/ApiTable.stories.tsx
@@ -5,6 +5,7 @@ import { ApiTable } from './ApiTable'
 import { ApiTableDefaultValue } from './ApiTableDefaultValue'
 import { ApiTableDescription } from './ApiTableDescription'
 import { ApiTableItem } from './ApiTableItem'
+import { ApiTableFunctionParameter } from './ApiTableFunctionParameter'
 
 const stories = storiesOf('API Table', module)
 
@@ -17,6 +18,23 @@ stories.add('Default', () => (
     <ApiTableItem name="endDate" type="Date | null">
       <ApiTableDefaultValue>null</ApiTableDefaultValue>
       <ApiTableDescription>The end date of the event.</ApiTableDescription>
+    </ApiTableItem>
+  </ApiTable>
+))
+
+stories.add('Function', () => (
+  <ApiTable>
+    <ApiTableItem name="render" type="Func">
+      <ApiTableDefaultValue>
+        <ApiTableFunctionParameter type="date">name1</ApiTableFunctionParameter>
+        <ApiTableFunctionParameter type="number">
+          name2
+        </ApiTableFunctionParameter>
+        <ApiTableFunctionParameter type="string">
+          name3
+        </ApiTableFunctionParameter>
+      </ApiTableDefaultValue>
+      <ApiTableDescription>desc</ApiTableDescription>
     </ApiTableItem>
   </ApiTable>
 ))

--- a/components/presenters/ApiTable/ApiTable.test.tsx
+++ b/components/presenters/ApiTable/ApiTable.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import {
+  ApiTable,
+  ApiTableDefaultValue,
+  ApiTableDescription,
+  ApiTableItem,
+} from '.'
+
+describe('API table', () => {
+  let wrapper: RenderResult
+
+  describe('all item props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <ApiTable>
+          <ApiTableItem isRequired name="startDate" type="Date">
+            <ApiTableDefaultValue>default</ApiTableDefaultValue>
+            <ApiTableDescription>desc</ApiTableDescription>
+          </ApiTableItem>
+        </ApiTable>
+      )
+    })
+
+    it('should render the name', () => {
+      expect(wrapper.getByText('startDate')).toBeInTheDocument()
+    })
+
+    it('should render the `Required` badge', () => {
+      expect(wrapper.getByText('Required')).toBeInTheDocument()
+    })
+
+    it('should render the type', () => {
+      expect(wrapper.getByText('Date')).toBeInTheDocument()
+    })
+
+    it('should render the default value', () => {
+      expect(wrapper.getByText('default')).toBeInTheDocument()
+    })
+
+    it('should render the description', () => {
+      expect(wrapper.getByText('desc')).toBeInTheDocument()
+    })
+  })
+
+  describe('minimal item props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <ApiTable>
+          <ApiTableItem name="startDate" type="Date">
+            <ApiTableDefaultValue />
+            <ApiTableDescription>desc</ApiTableDescription>
+          </ApiTableItem>
+        </ApiTable>
+      )
+    })
+
+    it('should not render the `Required` badge', () => {
+      expect(wrapper.queryAllByText('Required')).toHaveLength(0)
+    })
+
+    it('should render the default value', () => {
+      expect(wrapper.getByText('-')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/presenters/ApiTable/ApiTable.test.tsx
+++ b/components/presenters/ApiTable/ApiTable.test.tsx
@@ -8,6 +8,7 @@ import {
   ApiTableDescription,
   ApiTableItem,
 } from '.'
+import { ApiTableFunctionParameter } from './ApiTableFunctionParameter'
 
 describe('API table', () => {
   let wrapper: RenderResult
@@ -63,6 +64,44 @@ describe('API table', () => {
 
     it('should render the default value', () => {
       expect(wrapper.getByText('-')).toBeInTheDocument()
+    })
+  })
+
+  describe('function item', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <ApiTable>
+          <ApiTableItem name="startDate" type="Date">
+            <ApiTableDefaultValue>
+              <ApiTableFunctionParameter type="date">
+                name1
+              </ApiTableFunctionParameter>
+              <ApiTableFunctionParameter type="number">
+                name2
+              </ApiTableFunctionParameter>
+              <ApiTableFunctionParameter type="string">
+                name3
+              </ApiTableFunctionParameter>
+            </ApiTableDefaultValue>
+          </ApiTableItem>
+        </ApiTable>
+      )
+    })
+
+    it('should render the parameter names', () => {
+      const parameterNames = wrapper.getAllByTestId('api-table-parameter-name')
+      expect(parameterNames[0]).toHaveTextContent('name1')
+      expect(parameterNames[1]).toHaveTextContent('name2')
+      expect(parameterNames[2]).toHaveTextContent('name3')
+      expect(parameterNames).toHaveLength(3)
+    })
+
+    it('should render the parameter types', () => {
+      const parameterTypes = wrapper.getAllByTestId('api-table-parameter-type')
+      expect(parameterTypes[0]).toHaveTextContent('date')
+      expect(parameterTypes[1]).toHaveTextContent('number')
+      expect(parameterTypes[2]).toHaveTextContent('string')
+      expect(parameterTypes).toHaveLength(3)
     })
   })
 })

--- a/components/presenters/ApiTable/ApiTable.tsx
+++ b/components/presenters/ApiTable/ApiTable.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import { ApiTableItemProps } from './ApiTableItem'
+import { ComponentWithClass } from '../../../common/ComponentWithClass'
+
+export interface ApiTableProps extends ComponentWithClass {
+  children:
+    | React.ReactElement<ApiTableItemProps>
+    | React.ReactElement<ApiTableItemProps>[]
+}
+
+export const ApiTable: React.FC<ApiTableProps> = ({ children }) => (
+  <>{children}</>
+)
+
+ApiTable.displayName = 'ApiTable'

--- a/components/presenters/ApiTable/ApiTableDefaultValue.tsx
+++ b/components/presenters/ApiTable/ApiTableDefaultValue.tsx
@@ -1,22 +1,45 @@
 import React from 'react'
+import { isNil, isString } from 'lodash'
 
+import { ApiTableFunctionParameterProps } from './ApiTableFunctionParameter'
 import { StyledBodyRow } from './partials/StyledBodyRow'
 import { StyledBodyRowItem } from './partials/StyledBodyRowItem'
 import { StyledBodyRowValue } from './partials/StyledBodyRowValue'
+import { StyledParameter } from './partials/StyledParameter'
+import { StyledParameterName } from './partials/StyledParameterName'
+import { StyledParameters } from './partials/StyledParameters'
+import { StyledParameterType } from './partials/StyledParameterType'
 
 export interface ApiTableDefaultValueProps {
-  children?: string
+  children?:
+    | string
+    | React.ReactElement<ApiTableFunctionParameterProps>
+    | React.ReactElement<ApiTableFunctionParameterProps>[]
 }
 
 export const ApiTableDefaultValue: React.FC<ApiTableDefaultValueProps> = ({
   children,
-}) => (
-  <StyledBodyRow>
-    <StyledBodyRowItem>Default Value</StyledBodyRowItem>
-    <StyledBodyRowValue>
-      <code>{children || '-'}</code>
-    </StyledBodyRowValue>
-  </StyledBodyRow>
-)
+}) => {
+  if (isNil(children) || isString(children)) {
+    return (
+      <StyledBodyRow>
+        <StyledBodyRowItem>Default Value</StyledBodyRowItem>
+        <StyledBodyRowValue>
+          <code>{children || '-'}</code>
+        </StyledBodyRowValue>
+      </StyledBodyRow>
+    )
+  }
+
+  return (
+    <StyledBodyRow>
+      <StyledBodyRowItem>Default Value</StyledBodyRowItem>
+      <StyledBodyRowValue>
+        <code>Function</code>
+        <StyledParameters>{children}</StyledParameters>
+      </StyledBodyRowValue>
+    </StyledBodyRow>
+  )
+}
 
 ApiTableDefaultValue.displayName = 'ApiTableDefaultValue'

--- a/components/presenters/ApiTable/ApiTableDefaultValue.tsx
+++ b/components/presenters/ApiTable/ApiTableDefaultValue.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import { StyledBodyRow } from './partials/StyledBodyRow'
+import { StyledBodyRowItem } from './partials/StyledBodyRowItem'
+import { StyledBodyRowValue } from './partials/StyledBodyRowValue'
+
+export interface ApiTableDefaultValueProps {
+  children?: string
+}
+
+export const ApiTableDefaultValue: React.FC<ApiTableDefaultValueProps> = ({
+  children,
+}) => (
+  <StyledBodyRow>
+    <StyledBodyRowItem>Default Value</StyledBodyRowItem>
+    <StyledBodyRowValue>
+      <code>{children || '-'}</code>
+    </StyledBodyRowValue>
+  </StyledBodyRow>
+)
+
+ApiTableDefaultValue.displayName = 'ApiTableDefaultValue'

--- a/components/presenters/ApiTable/ApiTableDescription.tsx
+++ b/components/presenters/ApiTable/ApiTableDescription.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import { StyledBodyRow } from './partials/StyledBodyRow'
+import { StyledBodyRowItem } from './partials/StyledBodyRowItem'
+import { StyledBodyRowValue } from './partials/StyledBodyRowValue'
+
+export interface ApiTableDescriptionProps {
+  children: string
+}
+
+export const ApiTableDescription: React.FC<ApiTableDescriptionProps> = ({
+  children,
+}) => (
+  <StyledBodyRow>
+    <StyledBodyRowItem>Description</StyledBodyRowItem>
+    <StyledBodyRowValue as="p">{children}</StyledBodyRowValue>
+  </StyledBodyRow>
+)
+
+ApiTableDescription.displayName = 'ApiTableDescription'

--- a/components/presenters/ApiTable/ApiTableFunctionParameter.tsx
+++ b/components/presenters/ApiTable/ApiTableFunctionParameter.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { StyledParameter } from './partials/StyledParameter'
+import { StyledParameterName } from './partials/StyledParameterName'
+import { StyledParameterType } from './partials/StyledParameterType'
+
+export interface ApiTableFunctionParameterProps {
+  children: string
+  type: string
+}
+
+export const ApiTableFunctionParameter: React.FC<ApiTableFunctionParameterProps> = ({
+  children,
+  type,
+}) => (
+  <StyledParameter>
+    <StyledParameterName data-testid="api-table-parameter-name">
+      {children}
+    </StyledParameterName>
+    <StyledParameterType data-testid="api-table-parameter-type">
+      {type}
+    </StyledParameterType>
+  </StyledParameter>
+)
+
+ApiTableFunctionParameter.displayName = 'ApiTableFunctionParameter'

--- a/components/presenters/ApiTable/ApiTableItem.tsx
+++ b/components/presenters/ApiTable/ApiTableItem.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import {
+  Badge,
+  BADGE_COLOR,
+  BADGE_COLOR_VARIANT,
+  BADGE_SIZE,
+  BADGE_VARIANT,
+} from '@royalnavy/react-component-library'
+
+import { ApiTableDefaultValueProps } from './ApiTableDefaultValue'
+import { ApiTableDescriptionProps } from './ApiTableDescription'
+import { StyledBody } from './partials/StyledBody'
+import { StyledItem } from './partials/StyledItem'
+import { StyledHeader } from './partials/StyledHeader'
+import { StyledHeaderTitle } from './partials/StyledHeaderTitle'
+import { StyledHeaderRequired } from './partials/StyledHeaderRequired'
+
+export interface ApiTableItemProps {
+  children:
+    | React.ReactElement<ApiTableDefaultValueProps>
+    | React.ReactElement<ApiTableDefaultValueProps>[]
+    | React.ReactElement<ApiTableDescriptionProps>
+    | React.ReactElement<ApiTableDescriptionProps>[]
+  isRequired?: boolean
+  name: string
+  type: string
+}
+
+export const ApiTableItem: React.FC<ApiTableItemProps> = ({
+  children,
+  isRequired,
+  name,
+  type,
+}) => {
+  return (
+    <StyledItem>
+      <StyledHeader>
+        <StyledHeaderTitle>
+          {name}
+          {isRequired && (
+            <StyledHeaderRequired
+              color={BADGE_COLOR.DANGER}
+              colorVariant={BADGE_COLOR_VARIANT.FADED}
+              size={BADGE_SIZE.SMALL}
+              variant={BADGE_VARIANT.PILL}
+            >
+              Required
+            </StyledHeaderRequired>
+          )}
+        </StyledHeaderTitle>
+        <Badge
+          color={BADGE_COLOR.SUPA}
+          colorVariant={BADGE_COLOR_VARIANT.FADED}
+          size={BADGE_SIZE.SMALL}
+        >
+          {type}
+        </Badge>
+      </StyledHeader>
+      <StyledBody>{children}</StyledBody>
+    </StyledItem>
+  )
+}
+
+ApiTableItem.displayName = 'ApiTableItem'

--- a/components/presenters/ApiTable/index.ts
+++ b/components/presenters/ApiTable/index.ts
@@ -1,0 +1,4 @@
+export * from './ApiTable'
+export * from './ApiTableDefaultValue'
+export * from './ApiTableDescription'
+export * from './ApiTableItem'

--- a/components/presenters/ApiTable/partials/StyledBody.tsx
+++ b/components/presenters/ApiTable/partials/StyledBody.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, spacing } = selectors
+
+export const StyledBody = styled.div`
+  background-color: ${color('neutral', '000')};
+  padding: ${spacing('8')} ${spacing('8')} ${spacing('8')} ${spacing('10')};
+`

--- a/components/presenters/ApiTable/partials/StyledBodyRow.tsx
+++ b/components/presenters/ApiTable/partials/StyledBodyRow.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { spacing } = selectors
+
+export const StyledBodyRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+
+  & + & {
+    margin-top: ${spacing('4')};
+  }
+`

--- a/components/presenters/ApiTable/partials/StyledBodyRowItem.tsx
+++ b/components/presenters/ApiTable/partials/StyledBodyRowItem.tsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, fontSize, spacing } = selectors
+
+export const StyledBodyRowItem = styled.div`
+  width: 120px;
+  text-transform: uppercase;
+  font-size: ${fontSize('s')};
+  color: ${color('neutral', '300')};
+  font-weight: 600;
+  margin-top: ${spacing('4')};
+  transform: translateY(-1px);
+`

--- a/components/presenters/ApiTable/partials/StyledBodyRowValue.tsx
+++ b/components/presenters/ApiTable/partials/StyledBodyRowValue.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, fontSize, mq, spacing } = selectors
+
+export const StyledBodyRowValue = styled.div`
+  width: calc(100% - 120px);
+  padding-top: ${spacing('px')};
+  font-size: ${fontSize('base')};
+
+  ${mq({ gte: 'm' })`
+    font-size: ${fontSize('m')};
+  `}
+
+  > code {
+    font-size: ${fontSize('m')};
+    color: ${color('neutral', '500')};
+    font-weight: 400;
+    letter-spacing: -0.5px;
+    background-color: ${color('neutral', '000')};
+    display: block;
+    margin: ${spacing('px')} 0 ${spacing('4')};
+    padding-left: 0;
+  }
+`

--- a/components/presenters/ApiTable/partials/StyledHeader.tsx
+++ b/components/presenters/ApiTable/partials/StyledHeader.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { spacing } = selectors
+
+export const StyledHeader = styled.div`
+  padding: ${spacing('8')} ${spacing('7')} ${spacing('8')} ${spacing('10')};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`

--- a/components/presenters/ApiTable/partials/StyledHeaderRequired.tsx
+++ b/components/presenters/ApiTable/partials/StyledHeaderRequired.tsx
@@ -1,0 +1,9 @@
+import { Badge } from '@royalnavy/react-component-library'
+import { selectors } from '@royalnavy/design-tokens'
+import styled from 'styled-components'
+
+const { spacing } = selectors
+
+export const StyledHeaderRequired = styled(Badge)`
+  margin-left: ${spacing('4')};
+`

--- a/components/presenters/ApiTable/partials/StyledHeaderTitle.tsx
+++ b/components/presenters/ApiTable/partials/StyledHeaderTitle.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { fontSize } = selectors
+
+export const StyledHeaderTitle = styled.h1`
+  font-size: ${fontSize('m')};
+  margin: 0;
+`

--- a/components/presenters/ApiTable/partials/StyledItem.tsx
+++ b/components/presenters/ApiTable/partials/StyledItem.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, shadow, spacing } = selectors
+
+export const StyledItem = styled.div`
+  border: 1px solid ${color('neutral', '100')};
+  border-radius: 3px;
+  box-shadow: ${shadow('1')};
+  margin-top: ${spacing('12')};
+  & + & {
+    margin-top: ${spacing('9')};
+  }
+  max-width: 750px;
+`

--- a/components/presenters/ApiTable/partials/StyledParameter.tsx
+++ b/components/presenters/ApiTable/partials/StyledParameter.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, spacing } = selectors
+
+export const StyledParameter = styled.div`
+  background-color: ${color('neutral', 'white')};
+  list-style: none;
+  margin-top: -1px;
+  flex: 1 0 50%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${spacing('4')};
+  border-right: ${spacing('2')} solid ${color('neutral', '000')};
+  border-left: ${spacing('2')} solid ${color('neutral', '000')};
+  margin-bottom: ${spacing('4')};
+
+  &:last-child {
+    margin-bottom: ${spacing('4')};
+    max-width: 50%;
+  }
+`

--- a/components/presenters/ApiTable/partials/StyledParameterName.tsx
+++ b/components/presenters/ApiTable/partials/StyledParameterName.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { fontSize } = selectors
+
+export const StyledParameterName = styled.code`
+  background: none;
+  font-size: ${fontSize('base')};
+  font-weight: 400;
+  padding: 0;
+`

--- a/components/presenters/ApiTable/partials/StyledParameterType.tsx
+++ b/components/presenters/ApiTable/partials/StyledParameterType.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, fontSize, spacing } = selectors
+
+export const StyledParameterType = styled.span`
+  background-color: ${color('supa', '500')};
+  font-size: ${fontSize('xs')};
+  font-weight: 700;
+  color: ${color('neutral', 'white')};
+  border-radius: 2px;
+  line-height: 1;
+  text-transform: uppercase;
+  margin-left: ${spacing('4')};
+  padding: ${spacing('1')} ${spacing('2')};
+`

--- a/components/presenters/ApiTable/partials/StyledParameters.tsx
+++ b/components/presenters/ApiTable/partials/StyledParameters.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { spacing } = selectors
+
+export const StyledParameters = styled.ul`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+  border-radius: 4px;
+  padding: 0;
+  margin: 0 0 ${spacing('4')} -4px;
+`

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@royalnavy/fonts": "^2.35.0",
     "@royalnavy/icon-library": "^2.35.0",
     "@royalnavy/react-component-library": "^2.35.0",
+    "@types/lodash": "^4.14.168",
     "contentful": "^8.1.7",
     "next": "^10.0.0",
     "react": "17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,6 +2656,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/markdown-to-jsx@^6.11.0":
   version "6.11.3"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.3.tgz#cdd1619308fecbc8be7e6a26f3751260249b020e"


### PR DESCRIPTION
## Related issue
Closes #45 

## Overview
Adds `ApiTable`

## Reason
Required for documenting Design System components.

## Work carried out
- [x] Update `.gitignore`
- [x] Add component 

## Screenshot
### Default
![Screenshot 2021-03-03 at 09 44 12](https://user-images.githubusercontent.com/56078793/109786735-5fde0a80-7c05-11eb-94ce-2087d8b32eac.png)

### Function
![Screenshot 2021-03-03 at 09 44 46](https://user-images.githubusercontent.com/56078793/109786751-653b5500-7c05-11eb-9fab-807cd9861d7e.png)