### PR TITLE
Add LiveExample component

### DIFF
--- a/components/presenters/ApiTable/ApiTable.stories.tsx
+++ b/components/presenters/ApiTable/ApiTable.stories.tsx
@@ -7,7 +7,7 @@ import { ApiTableDescription } from './ApiTableDescription'
 import { ApiTableItem } from './ApiTableItem'
 import { ApiTableFunctionParameter } from './ApiTableFunctionParameter'
 
-const stories = storiesOf('API Table', module)
+const stories = storiesOf('ApiTable', module)
 
 stories.add('Default', () => (
   <ApiTable>

--- a/components/presenters/ApiTable/ApiTableDefaultValue.tsx
+++ b/components/presenters/ApiTable/ApiTableDefaultValue.tsx
@@ -5,10 +5,7 @@ import { ApiTableFunctionParameterProps } from './ApiTableFunctionParameter'
 import { StyledBodyRow } from './partials/StyledBodyRow'
 import { StyledBodyRowItem } from './partials/StyledBodyRowItem'
 import { StyledBodyRowValue } from './partials/StyledBodyRowValue'
-import { StyledParameter } from './partials/StyledParameter'
-import { StyledParameterName } from './partials/StyledParameterName'
 import { StyledParameters } from './partials/StyledParameters'
-import { StyledParameterType } from './partials/StyledParameterType'
 
 export interface ApiTableDefaultValueProps {
   children?:

--- a/components/presenters/LiveExample/LiveExample.stories.tsx
+++ b/components/presenters/LiveExample/LiveExample.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { LiveExample } from './LiveExample'
+
+const stories = storiesOf('LiveExample', module)
+
+stories.add('Default', () => (
+  <LiveExample>
+    <div>Example</div>
+  </LiveExample>
+))

--- a/components/presenters/LiveExample/LiveExample.test.tsx
+++ b/components/presenters/LiveExample/LiveExample.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+import { LiveExample } from './LiveExample'
+
+describe('Live example', () => {
+  let wrapper: RenderResult
+
+  describe('when', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <LiveExample>
+          <div>Example</div>
+        </LiveExample>
+      )
+    })
+
+    it('should render the example', () => {
+      expect(wrapper.getByText('Example')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/presenters/LiveExample/LiveExample.tsx
+++ b/components/presenters/LiveExample/LiveExample.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import { ComponentWithClass } from '../../../common/ComponentWithClass'
+import { StyledLiveExample } from './partials/StyledLiveExample'
+
+export const LiveExample: React.FC<ComponentWithClass> = (props) => (
+  <StyledLiveExample {...props} />
+)
+
+LiveExample.displayName = 'LiveExample'

--- a/components/presenters/LiveExample/partials/StyledLiveExample.tsx
+++ b/components/presenters/LiveExample/partials/StyledLiveExample.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { mq, spacing } = selectors
+
+export const StyledLiveExample = styled.div`
+  padding: 0 ${spacing('10')} ${spacing('10')};
+
+  ${mq({ gte: 's' })`
+    padding: 0 ${spacing('14')} ${spacing('12')};
+  `}
+
+  ${mq({ gte: 'xl' })`
+    padding: 0 ${spacing('12')};
+  `}
+`


### PR DESCRIPTION
## Related issue
Closes #47 

## Overview
Adds the `LiveExample` component.

## Reason
Required for presenting live examples of code.

## Work carried out
- [x] Add component
- [x] Tidy code

## Developer notes
Leaving the headings for now. May rethinking this later.