### PR TITLE
fix(Sidebar): Style APITable content sections differently

### DIFF
--- a/components/presenters/Sidebar/SidebarMenuItem.tsx
+++ b/components/presenters/Sidebar/SidebarMenuItem.tsx
@@ -7,15 +7,17 @@ import { StyledNavLink } from './partials/StyledNavLink'
 interface SidebarMenuItemProps extends ComponentWithClass {
   href: string
   title: string
+  isCode?: boolean
 }
 
 export const SidebarMenuItem: React.FC<SidebarMenuItemProps> = ({
   href,
   title,
+  isCode,
 }) => {
   return (
     <StyledSidebarMenuItem>
-      <StyledNavLink href={href} data-testid="sidebar-link">
+      <StyledNavLink $isCode={isCode} href={href} data-testid="sidebar-link">
         {title}
       </StyledNavLink>
     </StyledSidebarMenuItem>

--- a/components/presenters/Sidebar/partials/StyledNavLink.tsx
+++ b/components/presenters/Sidebar/partials/StyledNavLink.tsx
@@ -1,9 +1,13 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
+
+interface StyledNavLinkProps {
+  $isCode?: boolean
+}
 
 const { spacing, color, fontSize } = selectors
 
-export const StyledNavLink = styled.a`
+export const StyledNavLink = styled.a<StyledNavLinkProps>`
   position: relative;
   display: flex;
   justify-content: center;
@@ -33,4 +37,13 @@ export const StyledNavLink = styled.a`
       z-index: -1;
     }
   }
+
+  ${({ $isCode }) =>
+    $isCode &&
+    css`
+      font-weight: 300;
+      font-size: ${fontSize('base')};
+      font-family: 'Fira Code', 'Courier New', Courier, monospace;
+      padding-top: ${spacing('5')};
+    `}
 `

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -88,15 +88,18 @@ function renderNavigation(
   return sectionCollection?.items?.map(({ title, contentCollection }) => {
     return (
       <SidebarMenu key={title} title={title}>
-        {contentCollection?.items?.map(({ title: contentTitle }) => {
-          return (
-            <SidebarMenuItem
-              key={contentTitle}
-              href={`#${camelCase(contentTitle)}`}
-              title={contentTitle}
-            />
-          )
-        })}
+        {contentCollection?.items?.map(
+          ({ __typename, title: contentTitle }) => {
+            return (
+              <SidebarMenuItem
+                key={contentTitle}
+                href={`#${camelCase(contentTitle)}`}
+                title={contentTitle}
+                isCode={__typename === 'ApiTable'}
+              />
+            )
+          }
+        )}
       </SidebarMenu>
     )
   })


### PR DESCRIPTION
## Overview

APITable content sections should be styled differently in the sidebar.

## Screenshot

<img width="314" alt="Screenshot 2021-03-25 at 14 45 21" src="https://user-images.githubusercontent.com/48086589/112491955-bbb93080-8d78-11eb-8055-f567062b6886.png">


