### PR TITLE
ci(Release): Drop v prefix for release version

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -33,7 +33,7 @@ jobs:
           echo "::set-output name=version::$(git describe --tags $(git rev-list --tags --max-count=1))"
 
       - name: Create a Release
-        run: npx semantic-release
+        run: npx semantic-release --tag-format "\${version}"
         env:
            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,9 @@ jobs:
         id: initversion
         run: |
           echo "::set-output name=version::$(git describe --tags $(git rev-list --tags --max-count=1))"
+
       - name: Create a Release
-        run: npx semantic-release
+        run: npx semantic-release --tag-format "\${version}"
         env:
            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,6 +43,7 @@ jobs:
         id: postversion
         run: |
           echo "::set-output name=version::$(git describe --tags $(git rev-list --tags --max-count=1))"
+
       - name: Publish Site
         if: steps.initversion.outputs.version != steps.postversion.outputs.version
         run: |


### PR DESCRIPTION
## Related issue

closes #118 

## Overview

Drop 'v' prefix for release version in release workflows

