### PR TITLE
test(ApiTable): Fix drilling of `data-testid`

### DIFF
--- a/components/presenters/ApiTable/ApiTable.tsx
+++ b/components/presenters/ApiTable/ApiTable.tsx
@@ -9,8 +9,10 @@ export interface ApiTableProps extends ComponentWithClass {
     | React.ReactElement<ApiTableItemProps>[]
 }
 
-export const ApiTable: React.FC<ApiTableProps> = ({ children }) => (
-  <div data-testid="api-table">{children}</div>
+export const ApiTable: React.FC<ApiTableProps> = ({ children, ...rest }) => (
+  <div data-testid="api-table" {...rest}>
+    {children}
+  </div>
 )
 
 ApiTable.displayName = 'ApiTable'

--- a/cypress/specs/timeline/index.spec.ts
+++ b/cypress/specs/timeline/index.spec.ts
@@ -25,7 +25,6 @@ const content = [
   {
     text: 'useTimelineFrame',
     link: 'useTimelineFrame',
-    hasApiTable: true,
     hasApiReturnTable: true,
   },
   {
@@ -37,7 +36,6 @@ const content = [
   {
     text: 'useTimelineZoom',
     link: 'useTimelineZoom',
-    hasApiTable: true,
     hasApiReturnTable: true,
   },
   { text: 'Component APIs', link: 'componentApIs' },
@@ -70,7 +68,7 @@ describe('Compound Timeline', () => {
   describe('when browsing on desktop', () => {
     before(() => {
       // Block newrelic.js due to issues with Cypress networking
-      cy.intercept("**/newrelic.js", (req) => {
+      cy.intercept('**/newrelic.js', (req) => {
         req.reply("console.log('Fake New Relic script loaded');")
       })
 


### PR DESCRIPTION
Drill props to `ApiTable`, required for drilling `api-return-table`.