### PR TITLE
ci(SonarCloud): Exclude stories from coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,9 +6,8 @@ sonar.projectName=docs.royalnavy.io
 
 # Path to sources
 sonar.sources=pages,components,scripts,services
-sonar.exclusions=**/*.test.ts,**/*.test.tsx*
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*
-
+sonar.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx*,**/*.stories.tsx*
 
 # Path to tests
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Overview

Exclude Storybook stories from SonarCloud coverage reports.