### PR TITLE
feat(ContentBanner): Create base component

### DIFF
--- a/components/presenters/Docs/ContentBanner/ContentBanner.stories.tsx
+++ b/components/presenters/Docs/ContentBanner/ContentBanner.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { IconLightbulbOutline } from '@royalnavy/icon-library'
+
+import { ContentBanner } from '.'
+
+const stories = storiesOf('Docs/ContentBanner', module)
+
+stories.add('Default', () => (
+  <ContentBanner
+    icon={<IconLightbulbOutline />}
+    title="The documentation on this page is considered legacy."
+  >
+    We will be updating this content to our new principle-based format in the
+    near future.
+  </ContentBanner>
+))

--- a/components/presenters/Docs/ContentBanner/ContentBanner.test.tsx
+++ b/components/presenters/Docs/ContentBanner/ContentBanner.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+import { IconHome } from '@royalnavy/icon-library'
+
+import { ContentBanner } from '.'
+
+describe('ContentBanner', () => {
+  let wrapper: RenderResult
+
+  describe('with required props', () => {
+    beforeEach(() => {
+      wrapper = render(
+        <ContentBanner
+          icon={<IconHome data-testid="content-banner-icon" />}
+          title="Example Title"
+        >
+          Hello, World!
+        </ContentBanner>
+      )
+    })
+
+    it('renders the children', () => {
+      expect(wrapper.queryByText('Hello, World!')).toBeInTheDocument()
+    })
+
+    it('renders the title', () => {
+      expect(wrapper.queryByText('Example Title')).toBeInTheDocument()
+    })
+
+    it('renders the supplied SVG icon', () => {
+      expect(wrapper.queryByTestId('content-banner-icon')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/presenters/Docs/ContentBanner/ContentBanner.tsx
+++ b/components/presenters/Docs/ContentBanner/ContentBanner.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { ComponentWithClass } from '../../../../common/ComponentWithClass'
+import { StyledContentBanner } from './partials/StyledContentBanner'
+import { StyledTitle } from './partials/StyledTitle'
+import { StyledDescription } from './partials/StyledDescription'
+
+export interface ContentBannerProps extends ComponentWithClass {
+  icon?: React.ReactElement
+  title?: string
+}
+
+export const ContentBanner: React.FC<ContentBannerProps> = ({
+  icon,
+  title,
+  children,
+}) => {
+  return (
+    <StyledContentBanner>
+      {icon && <div>{icon}</div>}
+      <div>
+        {title && <StyledTitle>{title}</StyledTitle>}
+        <StyledDescription>{children}</StyledDescription>
+      </div>
+    </StyledContentBanner>
+  )
+}
+
+ContentBanner.displayName = 'ContentBanner'

--- a/components/presenters/Docs/ContentBanner/index.ts
+++ b/components/presenters/Docs/ContentBanner/index.ts
@@ -1,0 +1,1 @@
+export * from './ContentBanner'

--- a/components/presenters/Docs/ContentBanner/partials/StyledContentBanner.tsx
+++ b/components/presenters/Docs/ContentBanner/partials/StyledContentBanner.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, spacing, mq } = selectors
+
+export const StyledContentBanner = styled.div`
+  display: inline-flex;
+  width: 100vw;
+  align-items: flex-start;
+  justify-content: left;
+  background-color: ${color('action', '100')};
+  padding: ${spacing('9')};
+
+  ${mq({ gte: 's' })`
+    align-items: center;
+    width: auto;
+    max-width: 670px;
+    border-radius: 4px;
+  `}
+
+  svg {
+    width: auto;
+    height: 24px;
+    margin-right: ${spacing('9')};
+
+    ${mq({ gte: 's' })`
+      height: 38px;
+    `}
+  }
+`

--- a/components/presenters/Docs/ContentBanner/partials/StyledDescription.tsx
+++ b/components/presenters/Docs/ContentBanner/partials/StyledDescription.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color } = selectors
+
+export const StyledDescription = styled.p`
+  color: ${color('neutral', '500')};
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.5;
+`

--- a/components/presenters/Docs/ContentBanner/partials/StyledTitle.tsx
+++ b/components/presenters/Docs/ContentBanner/partials/StyledTitle.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, fontSize } = selectors
+
+export const StyledTitle = styled.span`
+  color: ${color('neutral', '500')};
+  font-size: ${fontSize('m')};
+  font-weight: 700;
+  line-height: 1.5;
+`


### PR DESCRIPTION
## Related issue

Closes #148

## Overview

Create base `ContentBanner` presentational component.

## Reason

>Create all presentational components in 'legacy' docs-site mocks.

## Work carried out

- [x] Create base component
- [x] Add automated tests and stories

## Screenshot

<img width="706" alt="Screenshot 2021-07-20 at 10 31 07" src="https://user-images.githubusercontent.com/48086589/126299004-b96a0012-1be7-4da0-a4a4-12e09f4fc070.png">
<img width="629" alt="Screenshot 2021-07-20 at 10 31 13" src="https://user-images.githubusercontent.com/48086589/126299014-dd0b39f0-2442-4bf0-9f61-ef0c4242b58b.png">

## Developer notes

https://github.com/Royal-Navy/docs.royalnavy.io/pull/165 should be merged ahead of this PR.
