### PR TITLE
Add component layout

### DIFF
--- a/components/layouts/Docs/Component.stories.tsx
+++ b/components/layouts/Docs/Component.stories.tsx
@@ -1,0 +1,196 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import {
+  Breadcrumbs,
+  BreadcrumbsItem,
+} from '@royalnavy/react-component-library'
+import { IconBookmark, IconLightbulbOutline } from '@royalnavy/icon-library'
+import Link from 'next/link'
+import { storiesOf } from '@storybook/react'
+
+import { Badge, BADGE_VARIANT } from '../../presenters/Docs/Badge'
+import { Component } from './Component'
+import { ContentBanner } from '../../presenters/Docs/ContentBanner'
+import { Footer } from '../../presenters/Docs/Footer'
+import { FooterExternalLink } from '../../presenters/Docs/Footer/FooterExternalLink'
+import {
+  Masthead,
+  MastheadMenu,
+  MastheadMenuItem,
+  MastheadSubMenu,
+  MastheadSubMenuItem,
+} from '../../presenters/Docs/Masthead'
+import { OnThisPageItem } from '../../presenters/Docs/OnThisPage/OnThisPageItem'
+import { SidebarFilter } from '../../presenters/Docs/Sidebar/SidebarFilter'
+import {
+  Sidebar,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarOverview,
+  SidebarOverviewMenuItem,
+} from '../../presenters/Docs/Sidebar'
+import { OnThisPage } from '../../presenters/Docs/OnThisPage'
+import { PageBanner } from '../../presenters/Docs/PageBanner'
+
+const stories = storiesOf('Docs/Layouts/Component', module)
+
+stories.add('Default', () => {
+  const breadcrumbs = (
+    <Breadcrumbs>
+      <BreadcrumbsItem link={<Link href="#home">Home</Link>} />
+      <BreadcrumbsItem link={<Link href="#components">Components</Link>} />
+      <BreadcrumbsItem link={<Link href="#sidebar">Sidebar</Link>} />
+    </Breadcrumbs>
+  )
+
+  const contentBanner = (
+    <ContentBanner
+      icon={<IconLightbulbOutline />}
+      title="The documentation on this page is considered legacy."
+    >
+      We will be updating this content to our new principle-based format in the
+      near future.
+    </ContentBanner>
+  )
+
+  const footer = (
+    <Footer
+      description="The Royal Navy Design System provides guidance and tools for building
+      high–quality Services within the Royal Navy. This project is open source
+      and its source code is available on GitHub."
+      externalLinks={[
+        <FooterExternalLink
+          icon={<IconBookmark />}
+          link={<Link href="#github">GitHub</Link>}
+        />,
+        <FooterExternalLink
+          icon={<IconBookmark />}
+          link={<Link href="#storybook">Storybook</Link>}
+        />,
+      ]}
+      license="All content is available under the Apache 2.0 licence, except where
+      otherwise stated."
+      siteLinks={[
+        <Link href="#accessibility">Accessibility</Link>,
+        <Link href="#privacy-policy">Privacy Policy</Link>,
+        <Link href="#contact">Contact</Link>,
+      ]}
+    />
+  )
+
+  const masthead = (
+    <Masthead version="3.0.0">
+      <MastheadMenu>
+        <MastheadMenuItem link={<Link href="#guidance">Guidance</Link>} />
+        <MastheadMenuItem link={<Link href="#principles">Principles</Link>} />
+        <MastheadMenuItem link={<Link href="#reference">Reference</Link>}>
+          <MastheadSubMenu>
+            <MastheadSubMenuItem
+              link={<Link href="#design-tokens">Design Tokens</Link>}
+            />
+            <MastheadSubMenuItem
+              link={<Link href="#components">Components</Link>}
+            />
+            <MastheadSubMenuItem
+              link={<Link href="#patterns">Patterns</Link>}
+            />
+            <MastheadSubMenuItem
+              link={<Link href="#frameworks">Frameworks</Link>}
+            />
+          </MastheadSubMenu>
+        </MastheadMenuItem>
+        <MastheadMenuItem link={<Link href="#resources">Resources</Link>} />
+        <MastheadMenuItem link={<Link href="#help">Help</Link>} />
+        <MastheadMenuItem link={<Link href="#blog">Blog</Link>} />
+      </MastheadMenu>
+    </Masthead>
+  )
+
+  const onThisPage = (
+    <OnThisPage>
+      <OnThisPageItem onClick={action('onClick')}>Overview</OnThisPageItem>
+      <OnThisPageItem onClick={action('onClick')}>Usage</OnThisPageItem>
+      <OnThisPageItem onClick={action('onClick')}>Anatomy</OnThisPageItem>
+      <OnThisPageItem onClick={action('onClick')}>
+        Hierarchy & placement
+      </OnThisPageItem>
+      <OnThisPageItem onClick={action('onClick')}>
+        Sizing & spacing
+      </OnThisPageItem>
+    </OnThisPage>
+  )
+
+  const pageBanner = (
+    <PageBanner>
+      Version <Badge variant={BADGE_VARIANT.DARK}>3.0.0</Badge> has been
+      released!&nbsp;
+      <a href="#">
+        Read the <strong>upgrade guide</strong>
+      </a>
+    </PageBanner>
+  )
+
+  const sidebar = (
+    <Sidebar title="Components">
+      <SidebarOverview>
+        <SidebarOverviewMenuItem
+          icon={<IconBookmark />}
+          link={<Link href="#storybook">Storybook</Link>}
+        />
+        <SidebarOverviewMenuItem
+          icon={<IconBookmark />}
+          link={<Link href="#axure-prototype-kit">Axure Prototype Kit</Link>}
+        />
+      </SidebarOverview>
+      <SidebarFilter
+        onChange={action('filter onChange')}
+        onSubmit={action('filter onSubmit')}
+      />
+      <SidebarMenu>
+        <SidebarMenuItem link={<Link href="#alert">Alert</Link>} />
+        <SidebarMenuItem link={<Link href="#avatar">Avatar</Link>} />
+        <SidebarMenuItem link={<Link href="#badge">Badge</Link>} />
+        <SidebarMenuItem link={<Link href="#breadcrumbs">Breadcrumbs</Link>} />
+        <SidebarMenuItem link={<Link href="#button">Button</Link>} />
+      </SidebarMenu>
+      <SidebarMenu title="Banners">
+        <SidebarMenuItem
+          link={<Link href="#dismissible-banner">Dismissible Banner</Link>}
+        />
+        <SidebarMenuItem
+          link={<Link href="#phase-banner">Phase Banner</Link>}
+        />
+      </SidebarMenu>
+      <SidebarMenu title="Cards">
+        <SidebarMenuItem link={<Link href="#content">Content</Link>} />
+        <SidebarMenuItem link={<Link href="#frame">Frame</Link>} />
+      </SidebarMenu>
+      <SidebarMenu title="Forms">
+        <SidebarMenuItem link={<Link href="#checkbox">Checkbox</Link>} />
+        <SidebarMenuItem link={<Link href="#date-picker">Date Picker</Link>} />
+        <SidebarMenuItem
+          link={<Link href="#number-input">Number Input</Link>}
+        />
+        <SidebarMenuItem link={<Link href="#radio">Radio</Link>} />
+        <SidebarMenuItem link={<Link href="#select">Select</Link>} />
+        <SidebarMenuItem link={<Link href="#text-input">Text Input</Link>} />
+        <SidebarMenuItem link={<Link href="#text-area">Text Area</Link>} />
+      </SidebarMenu>
+    </Sidebar>
+  )
+
+  return (
+    <Component
+      breadcrumbs={breadcrumbs}
+      contentBanner={contentBanner}
+      footer={footer}
+      masthead={masthead}
+      onThisPage={onThisPage}
+      pageBanner={pageBanner}
+      sidebar={sidebar}
+      title="Sidebar"
+    >
+      Content
+    </Component>
+  )
+})

--- a/components/layouts/Docs/Component.test.tsx
+++ b/components/layouts/Docs/Component.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import {
+  Breadcrumbs,
+  BreadcrumbsItem,
+} from '@royalnavy/react-component-library'
+import { IconBookmark, IconLightbulbOutline } from '@royalnavy/icon-library'
+import Link from 'next/link'
+import { render, RenderResult } from '@testing-library/react'
+
+import { Component } from './Component'
+import { ContentBanner } from '../../presenters/Docs/ContentBanner'
+import { Footer } from '../../presenters/Docs/Footer'
+import { FooterExternalLink } from '../../presenters/Docs/Footer/FooterExternalLink'
+import {
+  Masthead,
+  MastheadMenu,
+  MastheadMenuItem,
+} from '../../presenters/Docs/Masthead'
+import { OnThisPage } from '../../presenters/Docs/OnThisPage'
+import { OnThisPageItem } from '../../presenters/Docs/OnThisPage/OnThisPageItem'
+import { PageBanner } from '../../presenters/Docs/PageBanner'
+import {
+  Sidebar,
+  SidebarMenu,
+  SidebarMenuItem,
+} from '../../presenters/Docs/Sidebar'
+
+describe('Component docs layout', () => {
+  let wrapper: RenderResult
+
+  describe('all props', () => {
+    beforeEach(() => {
+      const breadcrumbs = (
+        <Breadcrumbs>
+          <BreadcrumbsItem link={<Link href="#link-1">Link 1</Link>} />
+          <BreadcrumbsItem link={<Link href="link-2">Link 2</Link>} />
+        </Breadcrumbs>
+      )
+
+      const contentBanner = (
+        <ContentBanner
+          icon={<IconLightbulbOutline />}
+          title="Content banner title"
+        >
+          Banner
+        </ContentBanner>
+      )
+
+      const footer = (
+        <Footer
+          description="description"
+          externalLinks={[
+            <FooterExternalLink
+              icon={<IconBookmark />}
+              link={<Link href="#link-3">Link 3</Link>}
+            />,
+          ]}
+          license="license"
+          siteLinks={[<Link href="#link-4">Link 4</Link>]}
+        />
+      )
+
+      const masthead = (
+        <Masthead version="3.0.0">
+          <MastheadMenu>
+            <MastheadMenuItem link={<Link href="#link-5">Link 5</Link>} />
+          </MastheadMenu>
+        </Masthead>
+      )
+
+      const onThisPage = (
+        <OnThisPage>
+          <OnThisPageItem onClick={() => undefined}>Item 1</OnThisPageItem>
+          <OnThisPageItem onClick={() => undefined}>Item 2</OnThisPageItem>
+        </OnThisPage>
+      )
+
+      const pageBanner = <PageBanner>Page banner</PageBanner>
+
+      const sidebar = (
+        <Sidebar title="Components">
+          <SidebarMenu title="Menu 1">
+            <SidebarMenuItem link={<Link href="#Link 6">Link 6</Link>} />
+          </SidebarMenu>
+        </Sidebar>
+      )
+
+      wrapper = render(
+        <Component
+          breadcrumbs={breadcrumbs}
+          contentBanner={contentBanner}
+          footer={footer}
+          masthead={masthead}
+          onThisPage={onThisPage}
+          pageBanner={pageBanner}
+          sidebar={sidebar}
+          title="Page title"
+        >
+          Content
+        </Component>
+      )
+    })
+
+    it('should render the breadcrumbs', () => {
+      expect(wrapper.getByText('Link 1')).toBeInTheDocument()
+      expect(wrapper.getByText('Link 2')).toBeInTheDocument()
+    })
+
+    it('should render the content banner', () => {
+      expect(wrapper.getByText('Banner')).toBeInTheDocument()
+    })
+
+    it('should render the footer', () => {
+      expect(wrapper.getByText('description')).toBeInTheDocument()
+    })
+
+    it('should render the masthead', () => {
+      expect(wrapper.getByText('Link 5')).toBeInTheDocument()
+    })
+
+    it('should render `On This Page`', () => {
+      expect(wrapper.getByText('On this page')).toBeInTheDocument()
+    })
+
+    it('should render the page banner', () => {
+      expect(wrapper.getByText('Page banner')).toBeInTheDocument()
+    })
+
+    it('should render the side bar items', () => {
+      expect(wrapper.getByText('Link 6')).toBeInTheDocument()
+    })
+
+    it('should render the title', () => {
+      expect(wrapper.getByText('Page title')).toBeInTheDocument()
+    })
+
+    it('should render the content', () => {
+      expect(wrapper.getByText('Content')).toBeInTheDocument()
+    })
+  })
+})

--- a/components/layouts/Docs/Component.tsx
+++ b/components/layouts/Docs/Component.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { BreadcrumbsItemProps } from '@royalnavy/react-component-library'
+import Head from 'next/head'
+import { Nav } from '@royalnavy/react-component-library/dist/types/common/Nav'
+
+import { ComponentWithClass } from '../../../common/ComponentWithClass'
+import { ContentBannerProps } from '../../presenters/Docs/ContentBanner'
+import { FooterProps } from '../../presenters/Docs/Footer'
+import { MastheadProps } from '../../presenters/Docs/Masthead'
+import { OnThisPageProps } from '../../presenters/Docs/OnThisPage'
+import { SidebarProps } from '../../presenters/Docs/Sidebar'
+import { StyledArticle } from './partials/StyledArticle'
+import { StyledBody } from './partials/StyledBody'
+import { StyledContent } from './partials/StyledContent'
+import { StyledMain } from './partials/StyledMain'
+import { StyledMastheadWrapper } from './partials/StyledMastheadWrapper'
+import { StyledOnThisPageWrapper } from './partials/StyledOnThisPageWrapper'
+import { StyledPageWrapper } from './partials/StyledPageWrapper'
+import { StyledSidebarWrapper } from './partials/StyledSidebarWrapper'
+import { StyledTitle } from './partials/StyledTitle'
+
+export interface LayoutComponentProps {
+  breadcrumbs: React.ReactElement<Nav<BreadcrumbsItemProps>>
+  contentBanner: React.ReactElement<ContentBannerProps>
+  footer: React.ReactElement<FooterProps>
+  masthead: React.ReactElement<MastheadProps>
+  onThisPage: React.ReactElement<OnThisPageProps>
+  pageBanner?: React.ReactElement<ComponentWithClass>
+  sidebar: React.ReactElement<SidebarProps>
+  title: string
+}
+
+export const Component: React.FC<LayoutComponentProps> = ({
+  breadcrumbs,
+  contentBanner,
+  children,
+  footer,
+  masthead,
+  onThisPage,
+  pageBanner,
+  sidebar,
+  title,
+}) => (
+  <>
+    <Head>
+      <title>Royal Navy Design System</title>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      <script type="text/javascript" src="/static/newrelic.js" />
+    </Head>
+    <StyledPageWrapper>
+      {pageBanner}
+      <StyledMastheadWrapper>{masthead}</StyledMastheadWrapper>
+      <StyledBody>
+        <StyledSidebarWrapper>{sidebar}</StyledSidebarWrapper>
+        <StyledMain>
+          <StyledArticle>
+            <div>
+              {breadcrumbs}
+              <StyledTitle>{title}</StyledTitle>
+              {contentBanner}
+              <StyledContent>{children}</StyledContent>
+            </div>
+            <StyledOnThisPageWrapper>{onThisPage}</StyledOnThisPageWrapper>
+          </StyledArticle>
+        </StyledMain>
+      </StyledBody>
+      {footer}
+    </StyledPageWrapper>
+  </>
+)
+
+Component.displayName = 'Component'

--- a/components/layouts/Docs/index.ts
+++ b/components/layouts/Docs/index.ts
@@ -1,0 +1,1 @@
+export * from './Component'

--- a/components/layouts/Docs/partials/StyledArticle.tsx
+++ b/components/layouts/Docs/partials/StyledArticle.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { mq, spacing } = selectors
+
+export const StyledArticle = styled.article`
+  display: flex;
+
+  & > div:first-of-type {
+    flex: 1;
+
+    & > nav {
+      padding: ${spacing('10')} ${spacing('10')} 0;
+
+      ${mq({ gte: 's' })`
+        padding: unset;
+      `}
+    }
+  }
+`

--- a/components/layouts/Docs/partials/StyledBody.tsx
+++ b/components/layouts/Docs/partials/StyledBody.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { mq, spacing } = selectors
+
+export const StyledBody = styled.div`
+  padding-top: ${spacing('6')};
+
+  ${mq({ gte: 's' })`
+    display: flex;
+    padding-top: unset;
+  `}
+`

--- a/components/layouts/Docs/partials/StyledContent.tsx
+++ b/components/layouts/Docs/partials/StyledContent.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { mq, spacing } = selectors
+
+export const StyledContent = styled.div`
+  flex: 1;
+  padding: ${spacing('12')} ${spacing('10')};
+
+  ${mq({ gte: 's' })`
+    padding: ${spacing('12')} 0;
+  `}
+`

--- a/components/layouts/Docs/partials/StyledMain.tsx
+++ b/components/layouts/Docs/partials/StyledMain.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, mq, spacing } = selectors
+
+export const StyledMain = styled.main`
+  background-color: ${color('neutral', 'white')};
+  box-shadow: inset 0px 1px 0px 0px ${color('neutral', '100')};
+  flex: 1;
+
+  ${mq({ gte: 's' })`
+    box-shadow: inset 1px 0px 0px 0px ${color('neutral', '100')};
+    padding: ${spacing('15')};
+  `}
+`

--- a/components/layouts/Docs/partials/StyledMastheadWrapper.tsx
+++ b/components/layouts/Docs/partials/StyledMastheadWrapper.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { zIndex } = selectors
+
+export const StyledMastheadWrapper = styled.div`
+  position: relative;
+  z-index: ${zIndex('masthead', 1)};
+`

--- a/components/layouts/Docs/partials/StyledOnThisPageWrapper.tsx
+++ b/components/layouts/Docs/partials/StyledOnThisPageWrapper.tsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, mq, spacing } = selectors
+
+export const StyledOnThisPageWrapper = styled.div`
+  display: none;
+  background-color: ${color('neutral', 'white')};
+  padding: 0 ${spacing('15')} ${spacing('15')};
+
+  ${mq({ gte: 's' })`
+    display: block;
+  `}
+`

--- a/components/layouts/Docs/partials/StyledPageWrapper.tsx
+++ b/components/layouts/Docs/partials/StyledPageWrapper.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color } = selectors
+
+export const StyledPageWrapper = styled.div`
+  background-color: ${color('neutral', '000')};
+`

--- a/components/layouts/Docs/partials/StyledSidebarWrapper.tsx
+++ b/components/layouts/Docs/partials/StyledSidebarWrapper.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { mq, spacing } = selectors
+
+export const StyledSidebarWrapper = styled.div`
+  display: none;
+  padding: ${spacing('4')};
+
+  ${mq({ gte: 's' })`
+    display: block;
+  `}
+`

--- a/components/layouts/Docs/partials/StyledTitle.tsx
+++ b/components/layouts/Docs/partials/StyledTitle.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { mq, spacing } = selectors
+
+export const StyledTitle = styled.h1`
+  position: relative;
+  margin: ${spacing('10')} ${spacing('10')} ${spacing('12')};
+  padding-left: 16px;
+  font-size: 2rem;
+  font-weight: 700;
+
+  &::before {
+    position: absolute;
+    left: 0;
+    content: '';
+    height: 37px;
+    width: 6px;
+    background-color: #6e72ff;
+    border-radius: 9999px;
+  }
+
+  ${mq({ gte: 's' })`
+    margin: ${spacing('10')} 0 ${spacing('12')};
+  `}
+`

--- a/components/presenters/Docs/Footer/Footer.tsx
+++ b/components/presenters/Docs/Footer/Footer.tsx
@@ -22,7 +22,7 @@ type ExternalLinksType =
   | React.ReactElement<FooterExternalLinkProps>
   | React.ReactElement<FooterExternalLinkProps>[]
 
-export interface ComponentNameProps extends ComponentWithClass {
+export interface FooterProps extends ComponentWithClass {
   description: string
   externalLinks: ExternalLinksType
   license: string
@@ -41,7 +41,7 @@ function mapLinks(
   })
 }
 
-export const Footer: React.FC<ComponentNameProps> = ({
+export const Footer: React.FC<FooterProps> = ({
   description,
   externalLinks,
   license,

--- a/components/presenters/Docs/Footer/partials/StyledFooter.tsx
+++ b/components/presenters/Docs/Footer/partials/StyledFooter.tsx
@@ -4,6 +4,7 @@ import { selectors } from '@royalnavy/design-tokens'
 const { color, mq } = selectors
 
 export const StyledFooter = styled.div`
+  position: relative;
   background-color: ${color('neutral', '500')};
   color: ${color('neutral', '100')};
   height: 542px;

--- a/components/presenters/Docs/Masthead/partials/StyledMasthead.tsx
+++ b/components/presenters/Docs/Masthead/partials/StyledMasthead.tsx
@@ -3,16 +3,17 @@ import { selectors } from '@royalnavy/design-tokens'
 
 import { StyledMastheadMenu } from './StyledMastheadMenu'
 
-const { spacing, shadow, mq } = selectors
+const { color, spacing, shadow, mq } = selectors
 
 interface StyledMastheadProps {
   $isOpen?: boolean
 }
 
-export const StyledMasthead = styled.div<StyledMastheadProps>`
+export const StyledMasthead = styled.header<StyledMastheadProps>`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  background-color: ${color('neutral', 'white')};
   height: 48px;
   padding: 0 ${spacing('10')};
   box-shadow: ${shadow('2')};

--- a/components/presenters/Docs/OnThisPage/partials/StyledOnThisPage.tsx
+++ b/components/presenters/Docs/OnThisPage/partials/StyledOnThisPage.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
 
-const { color, spacing } = selectors
+const { color, shadow, spacing } = selectors
 
-export const StyledOnThisPage = styled.div`
+export const StyledOnThisPage = styled.aside`
   padding: ${spacing('7')} ${spacing('9')} ${spacing('10')};
   border: 1px solid ${color('neutral', '100')};
   border-radius: 8px;
-  color: ${color('neutral', 'white')};
+  background-color: ${color('neutral', 'white')};
+  box-shadow: ${shadow('1')};
   width: 230px;
 `

--- a/components/presenters/Docs/Sidebar/Sidebar.tsx
+++ b/components/presenters/Docs/Sidebar/Sidebar.tsx
@@ -1,11 +1,19 @@
 import React from 'react'
 
 import { ComponentWithClass } from '../../../../common/ComponentWithClass'
+import { SidebarOverviewProps } from './SidebarOverview'
 import { StyledSidebar } from './partials/StyledSidebar'
 import { StyledSidebarMenu } from './partials/StyledSidebarMenu'
 import { StyledTitle } from './partials/StyledTitle'
+import { SidebarFilterProps } from './SidebarFilter'
+import { SidebarMenuProps } from './SidebarMenu'
 
-interface SidebarProps extends ComponentWithClass {
+export interface SidebarProps extends ComponentWithClass {
+  children:
+    | React.ReactElement<SidebarOverviewProps>
+    | React.ReactElement<SidebarFilterProps>
+    | React.ReactElement<SidebarMenuProps>
+    | React.ReactElement<SidebarMenuProps>[]
   title: string
 }
 

--- a/components/presenters/Docs/Sidebar/SidebarMenu.tsx
+++ b/components/presenters/Docs/Sidebar/SidebarMenu.tsx
@@ -5,7 +5,7 @@ import { StyledNavList } from './partials/StyledNavList'
 import { StyledNavSection } from './partials/StyledNavSection'
 import { StyledNavSectionTitle } from './partials/StyledNavSectionTitle'
 
-interface SidebarMenuProps extends ComponentWithClass {
+export interface SidebarMenuProps extends ComponentWithClass {
   title?: string
 }
 


### PR DESCRIPTION
## Related issue
Closes #155 

## Overview
Adds the layout for the component pages.

## Reason
Required for presenting component docs.

## Work carried out
- [x] Add layout

## Screenshot
### Mobile
![Screenshot 2021-07-29 at 14 45 53](https://user-images.githubusercontent.com/56078793/127503526-d2b61b7c-f515-4ab3-9c8c-091fac69d601.png)

### Desktop
![screencapture-localhost-6006-2021-07-29-14_46_32](https://user-images.githubusercontent.com/56078793/127503494-d74d18f6-cd43-4682-9811-3de14b06e501.png)

## Developer notes
There is [an issue](https://github.com/Royal-Navy/docs.royalnavy.io/issues/179) with the footer SVG which gives horizontal scrolling in the mobile view.
