### PR TITLE
test(Jest): Set global test environment to jsdom

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,4 +15,5 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/(?!(@royalnavy/design-tokens|hex-rgb)).+\\.js$',
   ],
+  testEnvironment: 'jest-environment-jsdom-global',
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,8 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^27.0.6",
     "jest-canvas-mock": "^2.3.1",
+    "jest-environment-jsdom": "^27.0.6",
+    "jest-environment-jsdom-global": "^2.0.4",
     "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^12.0.0",
     "jest-sonar-reporter": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10460,6 +10460,11 @@ jest-each@^27.0.6:
     jest-util "^27.0.6"
     pretty-format "^27.0.6"
 
+jest-environment-jsdom-global@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom-global/-/jest-environment-jsdom-global-2.0.4.tgz#b74704487a374a67ff301fc51cfeae30fae40e8e"
+  integrity sha512-1vB8q+PrszXW4Pf7Zgp3eQ4oNVbA7GY6+jmrg1qi6RtYRWDJ60/xdkhjqAbQpX8BRyvqQJYQi66LXER5YNeHXg==
+
 jest-environment-jsdom@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz#f66426c4c9950807d0a9f209c590ce544f73291f"


### PR DESCRIPTION
Set global test environment to jsdom:

https://www.npmjs.com/package/jest-environment-jsdom-global
https://jestjs.io/docs/configuration#testenvironment-string