### PR TITLE
staging_feat(Navigation): Handle nav item with no associated page

### DIFF
--- a/cypress/specs/docs/index.spec.ts
+++ b/cypress/specs/docs/index.spec.ts
@@ -25,6 +25,11 @@ describe('Docs Site: Components', () => {
       cy.visit('/components/alert')
     })
 
+    it('Component navigation item should not redirect user', () => {
+      cy.get('a').contains('Components').click()
+      cy.url().should('eq',  `${baseUrl}/components/alert#`)
+    })
+
     it('should render the page title', () => {
       cy.get(selectors.layout.h1).should('have.text', 'Alert')
     })


### PR DESCRIPTION
## Related issue

Closes #207

## Overview

Handle edge case where a navigation item has no associated page.

## Reason

>Navigation and pages do not always have a like-for-like relationship.

## Work carried out

- [x] Refactor `getStaticPaths` and `getStaticProps` data fetching
- [x] Handle Nav item with no page edge case
- [x] Added e2e Cypress test 