### PR TITLE
staging_feat(Masthead): Close nav sub menu on page click

### DIFF
--- a/components/layouts/Legacy/partials/StyledContent.tsx
+++ b/components/layouts/Legacy/partials/StyledContent.tsx
@@ -16,7 +16,7 @@ export const StyledContent = styled.div`
     font-size: ${fontSize('xxl')};
     line-height: 2;
     color: ${color('neutral', '500')};
-    margin-top: ${spacing('8')};
+    margin-top: ${spacing('12')};
     margin-bottom: ${spacing('4')};
   }
 

--- a/components/presenters/Docs/Masthead/Masthead.test.tsx
+++ b/components/presenters/Docs/Masthead/Masthead.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import Link from 'next/link'
 import '@testing-library/jest-dom/extend-expect'
-import { render, RenderResult, fireEvent } from '@testing-library/react'
+import {
+  render,
+  RenderResult,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react'
 
 import {
   Masthead,
@@ -53,6 +58,18 @@ describe('Masthead', () => {
 
       it('should display the sub navigation', () => {
         expect(wrapper.queryByText('Design Tokens')).toBeInTheDocument()
+      })
+
+      describe('and the user clicks outside of the sub menu', () => {
+        beforeEach(() => {
+          fireEvent.click(wrapper.getByTestId('masthead'))
+        })
+
+        it('hides the sub menu', () => {
+          return waitFor(() => {
+            expect(wrapper.queryByText('Design Tokens')).not.toBeVisible()
+          })
+        })
       })
     })
   })

--- a/components/presenters/Docs/Masthead/Masthead.tsx
+++ b/components/presenters/Docs/Masthead/Masthead.tsx
@@ -18,7 +18,7 @@ export const Masthead: React.FC<MastheadProps> = ({
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   return (
-    <StyledMasthead $isOpen={isOpen}>
+    <StyledMasthead $isOpen={isOpen} data-testid="masthead">
       <div>
         <RNDSLogo />
         <Badge variant="light">{version}</Badge>

--- a/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
+++ b/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { IconExpandMore, IconExpandLess } from '@royalnavy/icon-library'
+import { useDocumentClick } from '@royalnavy/react-component-library'
 
 import { ComponentWithClass } from '../../../../common/ComponentWithClass'
 
@@ -15,8 +16,13 @@ export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
   link,
   children,
 }) => {
+  const subMenuRef = useRef()
   const [showChildren, setShowChildren] = useState<boolean>(false)
   const hasChildren = !!children
+
+  useDocumentClick(subMenuRef, (_: Event) => {
+    setShowChildren(false)
+  })
 
   return (
     <StyledMastheadMenuItem $hasChildren={hasChildren}>
@@ -40,7 +46,7 @@ export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
           </StyledExpandButton>
         )}
       </div>
-      {hasChildren && showChildren && children}
+      {hasChildren && showChildren && <div ref={subMenuRef}>{children}</div>}
     </StyledMastheadMenuItem>
   )
 }

--- a/cypress/specs/docs/index.spec.ts
+++ b/cypress/specs/docs/index.spec.ts
@@ -25,6 +25,11 @@ describe('Docs Site: Components', () => {
       cy.visit('/components/alert')
     })
 
+    it('Component navigation item should not redirect user', () => {
+      cy.get('a').contains('Components').click()
+      cy.url().should('eq',  `${baseUrl}/components/alert#`)
+    })
+
     it('should render the page title', () => {
       cy.get(selectors.layout.h1).should('have.text', 'Alert')
     })

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -155,6 +155,7 @@ function renderBreadcrumb(slugs: string[]): React.ReactElement {
   const children = slugs.map((slug: string) => {
     return (
       <BreadcrumbsItem
+        key={slug}
         link={
           <Link href={`/${slug}`}>{upperFirst(slug.replace(/-/g, ' '))}</Link>
         }
@@ -167,6 +168,7 @@ function renderBreadcrumb(slugs: string[]): React.ReactElement {
     <Breadcrumbs>
       {[
         <BreadcrumbsItem
+          key="/"
           link={<Link href="/">Home</Link>}
           data-testid="breadcrumb-item"
         />,


### PR DESCRIPTION
## Related issue

Closes #203

## Overview

Hide sub menu on document click.

## Reason

>Sub menu should be hidden when a click event fired outside of the containing element.

## Work carried out

- [x] Add automated RTL test
- [x] Implement behaviour

## Screenshot

![2021-08-19 13 58 53](https://user-images.githubusercontent.com/48086589/130072553-168191c4-f949-4646-9799-353818ca9c39.gif)
