### PR TITLE
staging_feat(Sidebar): Change filter clear to keyboard shortcut

### DIFF
--- a/components/layouts/Legacy/Legacy.stories.tsx
+++ b/components/layouts/Legacy/Legacy.stories.tsx
@@ -142,10 +142,7 @@ stories.add('Default', () => {
           link={<Link href="#axure-prototype-kit">Axure Prototype Kit</Link>}
         />
       </SidebarOverview>
-      <SidebarFilter
-        onChange={action('filter onChange')}
-        onClear={action('filter onClear')}
-      />
+      <SidebarFilter onChange={action('filter onChange')} />
       <SidebarMenu>
         <SidebarMenuItem link={<Link href="#alert">Alert</Link>} />
         <SidebarMenuItem link={<Link href="#avatar">Avatar</Link>} />

--- a/components/layouts/Legacy/partials/StyledContent.tsx
+++ b/components/layouts/Legacy/partials/StyledContent.tsx
@@ -16,7 +16,7 @@ export const StyledContent = styled.div`
     font-size: ${fontSize('xxl')};
     line-height: 2;
     color: ${color('neutral', '500')};
-    margin-top: ${spacing('8')};
+    margin-top: ${spacing('12')};
     margin-bottom: ${spacing('4')};
   }
 

--- a/components/layouts/Legacy/partials/StyledOnThisPageWrapper.tsx
+++ b/components/layouts/Legacy/partials/StyledOnThisPageWrapper.tsx
@@ -9,6 +9,8 @@ export const StyledOnThisPageWrapper = styled.div`
   padding: 0 ${spacing('15')} ${spacing('15')};
 
   ${mq({ gte: 'l' })`
-    display: block;
+    display: flex;
+    align-items: flex-start;
+    height: auto;
   `}
 `

--- a/components/presenters/Docs/Masthead/Masthead.test.tsx
+++ b/components/presenters/Docs/Masthead/Masthead.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import Link from 'next/link'
 import '@testing-library/jest-dom/extend-expect'
-import { render, RenderResult, fireEvent } from '@testing-library/react'
+import {
+  render,
+  RenderResult,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react'
 
 import {
   Masthead,
@@ -53,6 +58,18 @@ describe('Masthead', () => {
 
       it('should display the sub navigation', () => {
         expect(wrapper.queryByText('Design Tokens')).toBeInTheDocument()
+      })
+
+      describe('and the user clicks outside of the sub menu', () => {
+        beforeEach(() => {
+          fireEvent.click(wrapper.getByTestId('masthead'))
+        })
+
+        it('hides the sub menu', () => {
+          return waitFor(() => {
+            expect(wrapper.queryByText('Design Tokens')).not.toBeVisible()
+          })
+        })
       })
     })
   })

--- a/components/presenters/Docs/Masthead/Masthead.tsx
+++ b/components/presenters/Docs/Masthead/Masthead.tsx
@@ -18,7 +18,7 @@ export const Masthead: React.FC<MastheadProps> = ({
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
   return (
-    <StyledMasthead $isOpen={isOpen}>
+    <StyledMasthead $isOpen={isOpen} data-testid="masthead">
       <div>
         <RNDSLogo />
         <Badge variant="light">{version}</Badge>

--- a/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
+++ b/components/presenters/Docs/Masthead/MastheadMenuItem.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { IconExpandMore, IconExpandLess } from '@royalnavy/icon-library'
+import { useDocumentClick } from '@royalnavy/react-component-library'
 
 import { ComponentWithClass } from '../../../../common/ComponentWithClass'
 
@@ -15,8 +16,13 @@ export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
   link,
   children,
 }) => {
+  const subMenuRef = useRef()
   const [showChildren, setShowChildren] = useState<boolean>(false)
   const hasChildren = !!children
+
+  useDocumentClick(subMenuRef, (_: Event) => {
+    setShowChildren(false)
+  })
 
   return (
     <StyledMastheadMenuItem $hasChildren={hasChildren}>
@@ -40,7 +46,7 @@ export const MastheadMenuItem: React.FC<MastheadMenuItemProps> = ({
           </StyledExpandButton>
         )}
       </div>
-      {hasChildren && showChildren && children}
+      {hasChildren && showChildren && <div ref={subMenuRef}>{children}</div>}
     </StyledMastheadMenuItem>
   )
 }

--- a/components/presenters/Docs/OnThisPage/partials/StyledOnThisPage.tsx
+++ b/components/presenters/Docs/OnThisPage/partials/StyledOnThisPage.tsx
@@ -4,6 +4,8 @@ import { selectors } from '@royalnavy/design-tokens'
 const { color, shadow, spacing } = selectors
 
 export const StyledOnThisPage = styled.aside`
+  position: sticky;
+  top: ${spacing('12')};
   padding: ${spacing('7')} ${spacing('9')} ${spacing('10')};
   border: 1px solid ${color('neutral', '100')};
   border-radius: 8px;

--- a/components/presenters/Docs/Sidebar/Sidebar.stories.tsx
+++ b/components/presenters/Docs/Sidebar/Sidebar.stories.tsx
@@ -27,10 +27,7 @@ stories.add('Default', () => (
         link={<Link href="#axure-prototype-kit">Axure Prototype Kit</Link>}
       />
     </SidebarOverview>
-    <SidebarFilter
-      onChange={action('filter onChange')}
-      onClear={action('filter onClear')}
-    />
+    <SidebarFilter onChange={action('filter onChange')} />
     <SidebarMenu>
       <SidebarMenuItem link={<Link href="#alert">Alert</Link>} />
       <SidebarMenuItem link={<Link href="#avatar">Avatar</Link>} />

--- a/components/presenters/Docs/Sidebar/Sidebar.test.tsx
+++ b/components/presenters/Docs/Sidebar/Sidebar.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
 import { IconBookmark } from '@royalnavy/icon-library'
 import Link from 'next/link'
-import { render, RenderResult } from '@testing-library/react'
+import { render, RenderResult, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { Sidebar } from './Sidebar'
@@ -14,18 +14,14 @@ import { SidebarOverviewMenuItem } from './SidebarOverviewMenuItem'
 
 describe('Sidebar', () => {
   let onChangeSpy: jest.SpyInstance
-  let onClearSpy: jest.SpyInstance
   let wrapper: RenderResult
 
   beforeEach(() => {
     const filterProps = {
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => undefined,
-      onClear: (e: React.MouseEvent<HTMLButtonElement>, value: string) =>
-        undefined,
     }
 
     onChangeSpy = jest.spyOn(filterProps, 'onChange')
-    onClearSpy = jest.spyOn(filterProps, 'onClear')
 
     wrapper = render(
       <Sidebar title="Components">
@@ -89,16 +85,16 @@ describe('Sidebar', () => {
 
       expect(onChangeSpy).toHaveBeenCalledTimes(3)
     })
+  })
 
-    describe('when the submit button is clicked', () => {
-      beforeEach(() => {
-        userEvent.click(wrapper.getByTestId('sidebar-filter-button'))
-      })
+  describe.skip('and the user presses the filter keyboard shotcut', () => {
+    beforeEach(async () => {
+      await userEvent.keyboard('/')
+    })
 
-      it('should call the `onClear` callback', () => {
-        expect(onClearSpy.mock.calls[0][1]).toEqual('')
-
-        expect(onClearSpy).toHaveBeenCalledTimes(1)
+    it('should focus the filter input', () => {
+      return waitFor(() => {
+        expect(wrapper.getByTestId('sidebar-filter-input')).toHaveFocus()
       })
     })
   })

--- a/components/presenters/Docs/Sidebar/SidebarFilter.tsx
+++ b/components/presenters/Docs/Sidebar/SidebarFilter.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 
 import { ComponentWithClass } from '../../../../common/ComponentWithClass'
 import { StyledFilter } from './partials/StyledFilter'
-import { StyledFilterButton } from './partials/StyledFilterButton'
+import { StyledFilterIcon } from './partials/StyledFilterIcon'
 import { StyledFilterEndAdornment } from './partials/StyledFilterEndAdornment'
 import { StyledFilterInput } from './partials/StyledFilterInput'
 import { StyledFilterInputWrapper } from './partials/StyledFilterInputWrapper'
@@ -10,21 +10,33 @@ import { StyledFilterOuterWrapper } from './partials/StyledFilterOuterWrapper'
 
 export interface SidebarFilterProps extends ComponentWithClass {
   onChange: (e: React.ChangeEvent<HTMLInputElement>, value: string) => void
-  onClear?: (e: React.FormEvent<HTMLButtonElement>, value: string) => void
 }
 
 export const SidebarFilter: React.FC<SidebarFilterProps> = ({
   className,
   onChange,
-  onClear,
 }) => {
+  const filterInputRef = useRef<HTMLInputElement>()
   const [value, setValue] = useState<string>('')
+  const [hasFocus, setHasFocus] = useState<boolean>(false)
+
+  useEffect(() => {
+    document.addEventListener('keyup', (e: KeyboardEvent) => {
+      if (e.code !== 'Slash') {
+        return
+      }
+
+      filterInputRef.current.focus()
+      setHasFocus(true)
+    })
+  }, [])
 
   return (
     <StyledFilter className={className}>
       <StyledFilterOuterWrapper>
-        <StyledFilterInputWrapper>
+        <StyledFilterInputWrapper $hasFocus={hasFocus}>
           <StyledFilterInput
+            ref={filterInputRef}
             value={value}
             data-testid="sidebar-filter-input"
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -33,17 +45,10 @@ export const SidebarFilter: React.FC<SidebarFilterProps> = ({
               onChange(e, newValue)
             }}
             placeholder="Filter..."
+            onBlur={(_) => setHasFocus(false)}
           />
           <StyledFilterEndAdornment>
-            <StyledFilterButton
-              data-testid="sidebar-filter-button"
-              onClick={(e: React.FormEvent<HTMLButtonElement>) => {
-                setValue('')
-                onClear(e, '')
-              }}
-            >
-              /
-            </StyledFilterButton>
+            <StyledFilterIcon>/</StyledFilterIcon>
           </StyledFilterEndAdornment>
         </StyledFilterInputWrapper>
       </StyledFilterOuterWrapper>

--- a/components/presenters/Docs/Sidebar/partials/StyledFilterIcon.tsx
+++ b/components/presenters/Docs/Sidebar/partials/StyledFilterIcon.tsx
@@ -3,7 +3,7 @@ import { selectors } from '@royalnavy/design-tokens'
 
 export const { color, fontSize } = selectors
 
-export const StyledFilterButton = styled.button`
+export const StyledFilterIcon = styled.div`
   background-color: ${color('neutral', 'white')};
   border: 1px solid ${color('neutral', '200')};
   border-radius: 4px;
@@ -14,4 +14,6 @@ export const StyledFilterButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
+  user-select: none;
 `

--- a/components/presenters/Docs/Sidebar/partials/StyledFilterInputWrapper.tsx
+++ b/components/presenters/Docs/Sidebar/partials/StyledFilterInputWrapper.tsx
@@ -1,8 +1,23 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
 
-export const StyledFilterInputWrapper = styled.div`
+const { color } = selectors
+
+interface StyledFilterInputWrapperProps {
+  $hasFocus: boolean
+}
+
+export const StyledFilterInputWrapper = styled.div<StyledFilterInputWrapperProps>`
   position: relative;
   flex-grow: 1;
   order: 1;
   display: flex;
+  border: 2px solid transparent;
+  border-radius: 8px;
+
+  ${({ $hasFocus }) =>
+    $hasFocus &&
+    css`
+      border-color: ${color('neutral', '200')};
+    `};
 `

--- a/cypress/specs/docs/index.spec.ts
+++ b/cypress/specs/docs/index.spec.ts
@@ -25,6 +25,11 @@ describe('Docs Site: Components', () => {
       cy.visit('/components/alert')
     })
 
+    it('Component navigation item should not redirect user', () => {
+      cy.get('a').contains('Components').click()
+      cy.url().should('eq',  `${baseUrl}/components/alert#`)
+    })
+
     it('should render the page title', () => {
       cy.get(selectors.layout.h1).should('have.text', 'Alert')
     })

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -155,6 +155,7 @@ function renderBreadcrumb(slugs: string[]): React.ReactElement {
   const children = slugs.map((slug: string) => {
     return (
       <BreadcrumbsItem
+        key={slug}
         link={
           <Link href={`/${slug}`}>{upperFirst(slug.replace(/-/g, ' '))}</Link>
         }
@@ -167,6 +168,7 @@ function renderBreadcrumb(slugs: string[]): React.ReactElement {
     <Breadcrumbs>
       {[
         <BreadcrumbsItem
+          key="/"
           link={<Link href="/">Home</Link>}
           data-testid="breadcrumb-item"
         />,

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -260,7 +260,7 @@ export const GenericPage: React.FC<GenericPageProps> = ({
   const { version } = useDesignSystemVersion()
 
   const handleSidebarFilter = (
-    e: React.ChangeEvent<HTMLInputElement>,
+    _: React.ChangeEvent<HTMLInputElement>,
     newValue: string
   ): void => {
     setSidebarItems(
@@ -341,10 +341,7 @@ export const GenericPage: React.FC<GenericPageProps> = ({
           link={<Link href="#axure-prototype-kit">Axure Prototype Kit</Link>}
         />
       </SidebarOverview>
-      <SidebarFilter
-        onChange={handleSidebarFilter}
-        onClear={handleSidebarFilter}
-      />
+      <SidebarFilter onChange={handleSidebarFilter} />
       {renderSidebarItems(sidebarItems)}
     </Sidebar>
   )


### PR DESCRIPTION
## Related issue

Closes #204

## Overview

Change behaviour of sidebar filter input from clear button to keyboard ('/' key) activated focus.

## Reason

>This behaviour was incorrectly implemented based on assumptions made from mocks.

## Work carried out

- [x] Add automated RTL test
- [x] Change behaviour as required

## Screenshot

![2021-08-19 15 26 24](https://user-images.githubusercontent.com/48086589/130086416-b46f30d7-688d-40f0-b64e-563493ea4668.gif)

## Developer notes

No current spec for styling associated with behaviour - designer needs to do this.
