### PR TITLE
ci(E2E_tests): Capture screenshots for failed end to end tests

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -62,6 +62,13 @@ jobs:
             build: yarn build
             start: yarn start
 
+        - name: Save images for failed tests
+          if: failure()
+          uses: actions/upload-artifact@v2
+          with:
+            name: cypress_screenshots
+            path: cypress/screenshots/
+
 
   Automerge:
     name: Merge Dependabot PR's

--- a/.github/workflows/build_and_test_feature.yml
+++ b/.github/workflows/build_and_test_feature.yml
@@ -121,4 +121,11 @@ jobs:
             build: yarn build
             start: yarn start
 
+        - name: Save images for failed tests
+          if: failure()
+          uses: actions/upload-artifact@v2
+          with:
+            name: cypress_screenshots
+            path: cypress/screenshots/
+
 

--- a/.github/workflows/build_and_test_master.yml
+++ b/.github/workflows/build_and_test_master.yml
@@ -85,3 +85,10 @@ jobs:
           with:
             build: yarn build
             start: yarn start
+
+        - name: Save images for failed tests
+          if: failure()
+          uses: actions/upload-artifact@v2
+          with:
+            name: cypress_screenshots
+            path: cypress/screenshots/

--- a/cypress.json
+++ b/cypress.json
@@ -2,7 +2,7 @@
   "baseUrl": "http://localhost:3000",
   "defaultCommandTimeout": 10000,
   "integrationFolder": "cypress/specs",
-  "screenshotOnRunFailure": false,
+  "screenshotOnRunFailure": true,
   "video": false,
   "viewportWidth": 1024,
   "viewportHeight": 768


### PR DESCRIPTION
## Related issue

Closes #111 

## Overview

Capture screenshots for failed e2e tests, save as a workflow artifact

## Link to preview

https://github.com/Royal-Navy/docs.royalnavy.io/actions/runs/1150255043

## Reason

Assist debugging when e2e tests fail

## Work carried out

- [x] Turn on screenshot capture in Cypress config
- [x] Enabled screenshot capture for failed e2e tests in Build & Test Feature workflow
- [x] Enabled screenshot capture for failed e2e tests in Build & Test Master workflow
- [x] Enabled screenshot capture for failed e2e tests in Automerge workflow


## Screenshot


![ci_e2e_test](https://user-images.githubusercontent.com/61734183/130225789-a55247a6-308c-4904-b471-db91e95f5e72.jpg)


