### PR TITLE
Present embedded code blocks

### DIFF
--- a/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
+++ b/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
@@ -208,4 +208,56 @@ describe('Docs/ContentBlockAdapter', () => {
       expect(wrapper.getByTestId('markdown-table')).toBeInTheDocument()
     })
   })
+
+  describe('with code block linked entry', () => {
+    beforeEach(() => {
+      const fields = {
+        title: 'Example Title',
+        description: {
+          json: {
+            nodeType: 'document',
+            data: {},
+            content: [
+              {
+                nodeType: 'embedded-entry-inline',
+                content: [],
+                data: {
+                  target: {
+                    sys: {
+                      id: '47DP1urOOAdvdXaCGeheqZ',
+                      type: 'Link',
+                      linkType: 'Entry',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          links: {
+            entries: {
+              inline: [
+                {
+                  sys: {
+                    id: '47DP1urOOAdvdXaCGeheqZ',
+                  },
+                  __typename: 'CodeBlock',
+                  sourceCode: '// code',
+                },
+              ],
+            },
+          },
+        },
+        image: {
+          title: 'Example Image',
+          url: 'https://www.google.com',
+        },
+      }
+
+      wrapper = render(<ContentBlockAdapter fields={fields} />)
+    })
+
+    it('renders the code block', () => {
+      expect(wrapper.getByTestId('codeblock')).toBeInTheDocument()
+    })
+  })
 })

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -2639,6 +2639,85 @@ export type PageByPathQuery = (
                       { __typename?: 'Sys' }
                       & Pick<Sys, 'id'>
                     ) }
+                  )>>, inline: Array<Maybe<(
+                    { __typename: 'ApiField' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'ApiTable' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'CodeBlock' }
+                    & Pick<CodeBlock, 'sourceCode'>
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'ContentBlock' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'Hero' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'Homepage' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'LiveExample' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'MarkdownTable' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'Navigation' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'NavigationElement' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'Page' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'Section' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'SimpleCard' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
                   )>> }
                 ) }
               ) }

--- a/graphql/queries/PageByPath.graphql
+++ b/graphql/queries/PageByPath.graphql
@@ -61,6 +61,15 @@ query PageByPath($path: String!) {
                           markdown
                         }
                       }
+                      inline {
+                        sys {
+                          id
+                        }
+                        __typename
+                        ... on CodeBlock {
+                          sourceCode
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
## Related issue
Closes #245

## Overview
Presents embedded code blocks on the page.

## Reason
> Format Embedded In-line Code Blocks so that they display in the UI

## Work carried out
- [x] Present `CodeBlock`

## Screenshot
![Screenshot 2021-09-13 at 10 45 55](https://user-images.githubusercontent.com/56078793/133063927-3b57bd3e-289a-4801-8988-68cbcf5d1f12.png)

## Developer notes
Styles will be sorted by @hxltrhuxze 
