### PR TITLE
Add swatch

### DIFF
--- a/components/adapters/Docs/ContentBlockAdapter.tsx
+++ b/components/adapters/Docs/ContentBlockAdapter.tsx
@@ -8,6 +8,7 @@ import { MarkdownTable } from '../../presenters/Docs/MarkdownTable'
 
 import { ComponentWithClass } from '../../../common/ComponentWithClass'
 import { CodeBlock } from '../../presenters/Framework/CodeBlock'
+import { Swatch, SwatchColour } from '../../presenters/Docs/Swatch'
 
 interface ContentBlockAdapterProps extends ComponentWithClass {
   fields: Record<string, any>
@@ -30,6 +31,19 @@ type MarkdownTableType = {
 type CodeBlockType = {
   __typename: string
   sourceCode: string
+}
+
+type SwatchColourType = {
+  name: string
+  colour: string
+  isDark: boolean
+}
+
+type SwatchType = {
+  __typename: string
+  colourCollection: {
+    items: SwatchColourType[]
+  }
 }
 
 const { color, fontSize, spacing } = selectors
@@ -84,11 +98,32 @@ function getRichTextRenderOptions(links) {
         )
       },
       [BLOCKS.EMBEDDED_ENTRY]: (node) => {
-        const entryBlockMap = getEntryMap<MarkdownTableType>(links, 'entries')
+        const entryBlockMap = getEntryMap<MarkdownTableType | SwatchType>(
+          links,
+          'entries'
+        )
         const entry = entryBlockMap.get(node.data.target.sys.id)
 
         if (entry.__typename === 'MarkdownTable') {
-          return <MarkdownTable>{entry.markdown}</MarkdownTable>
+          return (
+            <MarkdownTable>
+              {(entry as MarkdownTableType).markdown}
+            </MarkdownTable>
+          )
+        }
+
+        if (entry.__typename === 'Swatch') {
+          return (
+            <Swatch>
+              {(entry as SwatchType).colourCollection.items.map(
+                ({ colour, isDark, name }) => (
+                  <SwatchColour colour={colour} isDark={isDark} key={colour}>
+                    {name}
+                  </SwatchColour>
+                )
+              )}
+            </Swatch>
+          )
         }
 
         return null

--- a/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
+++ b/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
@@ -260,4 +260,64 @@ describe('Docs/ContentBlockAdapter', () => {
       expect(wrapper.getByTestId('codeblock')).toBeInTheDocument()
     })
   })
+
+  describe('with swatch linked entry', () => {
+    beforeEach(() => {
+      const fields = {
+        title: 'Example Title',
+        description: {
+          json: {
+            nodeType: 'document',
+            data: {},
+            content: [
+              {
+                nodeType: 'embedded-entry-block',
+                content: [],
+                data: {
+                  target: {
+                    sys: {
+                      id: '5GimEiW01oX9nKha7HZjTm',
+                      type: 'Link',
+                      linkType: 'Entry',
+                    },
+                  },
+                },
+              },
+            ],
+          },
+          links: {
+            entries: {
+              block: [
+                {
+                  sys: {
+                    id: '5GimEiW01oX9nKha7HZjTm',
+                  },
+                  __typename: 'Swatch',
+                  colourCollection: {
+                    items: [
+                      {
+                        name: 'White',
+                        colour: '#FFFFFF',
+                        isDark: false,
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+        image: {
+          title: 'Example Image',
+          url: 'https://www.google.com',
+        },
+      }
+
+      wrapper = render(<ContentBlockAdapter fields={fields} />)
+    })
+
+    it('renders the swatch', () => {
+      expect(wrapper.getByTestId('swatch')).toBeInTheDocument()
+    })
+  })
 })

--- a/components/presenters/Docs/Swatch/Swatch.stories.tsx
+++ b/components/presenters/Docs/Swatch/Swatch.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { Swatch, SwatchColour } from '.'
+
+const stories = storiesOf('Docs/Swatch', module)
+
+stories.add('Default', () => (
+  <Swatch>
+    <SwatchColour colour="#0a141b" isDark>
+      900
+    </SwatchColour>
+    <SwatchColour colour="#0c1720" isDark>
+      800
+    </SwatchColour>
+    <SwatchColour colour="#12202b" isDark>
+      700
+    </SwatchColour>
+    <SwatchColour colour="#1c2d39" isDark>
+      600
+    </SwatchColour>
+    <SwatchColour colour="#233745" isDark>
+      500
+    </SwatchColour>
+    <SwatchColour colour="#3e5667" isDark>
+      400
+    </SwatchColour>
+    <SwatchColour colour="#748999">300</SwatchColour>
+    <SwatchColour colour="#b8c7d2">200</SwatchColour>
+    <SwatchColour colour="#e2e9ee">100</SwatchColour>
+    <SwatchColour colour="#f8fafc">000</SwatchColour>
+    <SwatchColour colour="#0a141b" isDark>
+      Black
+    </SwatchColour>
+    <SwatchColour colour="#FFFFFF">White</SwatchColour>
+  </Swatch>
+))

--- a/components/presenters/Docs/Swatch/Swatch.test.tsx
+++ b/components/presenters/Docs/Swatch/Swatch.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render, RenderResult } from '@testing-library/react'
+
+import { Swatch, SwatchColour } from '.'
+
+describe('Swatch', () => {
+  let wrapper: RenderResult
+
+  beforeEach(() => {
+    wrapper = render(
+      <Swatch>
+        <SwatchColour colour="#0a141b" isDark>
+          900
+        </SwatchColour>
+        <SwatchColour colour="#0c1720" isDark>
+          800
+        </SwatchColour>
+        <SwatchColour colour="#FFFFFF">White</SwatchColour>
+      </Swatch>
+    )
+  })
+
+  it('should render the items', () => {
+    const items = wrapper.getAllByTestId('swatch-colour')
+
+    expect(items[0]).toHaveTextContent('900')
+    expect(items[0]).toHaveTextContent('#0a141b')
+    expect(items[1]).toHaveTextContent('800')
+    expect(items[1]).toHaveTextContent('#0c1720')
+    expect(items[2]).toHaveTextContent('White')
+    expect(items[2]).toHaveTextContent('#FFFFFF')
+    expect(items).toHaveLength(3)
+  })
+})

--- a/components/presenters/Docs/Swatch/Swatch.tsx
+++ b/components/presenters/Docs/Swatch/Swatch.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { StyledSwatch } from './partials/StyledSwatch'
 
 export const Swatch: React.FC = (props) => {
-  return <StyledSwatch {...props} />
+  return <StyledSwatch data-testid="swatch" {...props} />
 }
 
 Swatch.displayName = 'Swatch'

--- a/components/presenters/Docs/Swatch/Swatch.tsx
+++ b/components/presenters/Docs/Swatch/Swatch.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+import { StyledSwatch } from './partials/StyledSwatch'
+
+export const Swatch: React.FC = (props) => {
+  return <StyledSwatch {...props} />
+}
+
+Swatch.displayName = 'Swatch'

--- a/components/presenters/Docs/Swatch/SwatchColour.tsx
+++ b/components/presenters/Docs/Swatch/SwatchColour.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { StyledColour } from './partials/StyledColour'
+import { StyledLabel } from './partials/StyledLabel'
+
+export interface SwatchColourProps {
+  colour: string
+  isDark?: boolean
+}
+
+export const SwatchColour: React.FC<SwatchColourProps> = ({
+  children,
+  colour,
+  isDark,
+}) => (
+  <StyledColour
+    $backgroundColor={colour}
+    $isDark={isDark}
+    data-testid="swatch-colour"
+  >
+    <StyledLabel>{children}</StyledLabel>
+    <StyledLabel>{colour}</StyledLabel>
+  </StyledColour>
+)
+
+SwatchColour.displayName = 'ColourSwatchItem'

--- a/components/presenters/Docs/Swatch/index.ts
+++ b/components/presenters/Docs/Swatch/index.ts
@@ -1,0 +1,2 @@
+export * from './Swatch'
+export * from './SwatchColour'

--- a/components/presenters/Docs/Swatch/partials/StyledColour.tsx
+++ b/components/presenters/Docs/Swatch/partials/StyledColour.tsx
@@ -1,0 +1,23 @@
+import styled, { css } from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { color, mq, spacing } = selectors
+
+interface StyledItemProps {
+  $backgroundColor: string
+  $isDark: boolean
+}
+
+export const StyledColour = styled.div<StyledItemProps>`
+  padding: ${spacing('14')} ${spacing('4')} ${spacing('4')};
+  width: 25%;
+
+  ${mq({ gte: 'm' })`
+    width: 20%;
+  `}
+
+  ${({ $backgroundColor, $isDark }) => css`
+    background-color: ${$backgroundColor};
+    color: ${color('neutral', $isDark ? 'white' : '600')}};
+  `}
+`

--- a/components/presenters/Docs/Swatch/partials/StyledLabel.tsx
+++ b/components/presenters/Docs/Swatch/partials/StyledLabel.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { fontSize, spacing } = selectors
+
+export const StyledLabel = styled.span`
+  font-size: ${fontSize('s')};
+  font-weight: 500;
+  width: 100%;
+  display: block;
+
+  &:first-child {
+    margin-bottom: ${spacing('2')};
+  }
+`

--- a/components/presenters/Docs/Swatch/partials/StyledSwatch.tsx
+++ b/components/presenters/Docs/Swatch/partials/StyledSwatch.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+import { selectors } from '@royalnavy/design-tokens'
+
+const { spacing } = selectors
+
+export const StyledSwatch = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  max-width: 100%;
+  margin-top: ${spacing('10')};
+`

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -1831,6 +1831,10 @@ export type Query = {
   __typename?: 'Query';
   asset?: Maybe<Asset>;
   assetCollection?: Maybe<AssetCollection>;
+  swatchColour?: Maybe<SwatchColour>;
+  swatchColourCollection?: Maybe<SwatchColourCollection>;
+  swatch?: Maybe<Swatch>;
+  swatchCollection?: Maybe<SwatchCollection>;
   markdownTable?: Maybe<MarkdownTable>;
   markdownTableCollection?: Maybe<MarkdownTableCollection>;
   simpleCard?: Maybe<SimpleCard>;
@@ -1875,6 +1879,40 @@ export type QueryAssetCollectionArgs = {
   locale?: Maybe<Scalars['String']>;
   where?: Maybe<AssetFilter>;
   order?: Maybe<Array<Maybe<AssetOrder>>>;
+};
+
+
+export type QuerySwatchColourArgs = {
+  id: Scalars['String'];
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+export type QuerySwatchColourCollectionArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+  where?: Maybe<SwatchColourFilter>;
+  order?: Maybe<Array<Maybe<SwatchColourOrder>>>;
+};
+
+
+export type QuerySwatchArgs = {
+  id: Scalars['String'];
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+export type QuerySwatchCollectionArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+  where?: Maybe<SwatchFilter>;
+  order?: Maybe<Array<Maybe<SwatchOrder>>>;
 };
 
 
@@ -2349,6 +2387,183 @@ export enum SimpleCardOrder {
   SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatch) */
+export type Swatch = Entry & {
+  __typename?: 'Swatch';
+  sys: Sys;
+  contentfulMetadata: ContentfulMetadata;
+  linkedFrom?: Maybe<SwatchLinkingCollections>;
+  title?: Maybe<Scalars['String']>;
+  colourCollection?: Maybe<SwatchColourCollection>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatch) */
+export type SwatchLinkedFromArgs = {
+  allowedLocales?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatch) */
+export type SwatchTitleArgs = {
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatch) */
+export type SwatchColourCollectionArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+export type SwatchCollection = {
+  __typename?: 'SwatchCollection';
+  total: Scalars['Int'];
+  skip: Scalars['Int'];
+  limit: Scalars['Int'];
+  items: Array<Maybe<Swatch>>;
+};
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatchColour) */
+export type SwatchColour = Entry & {
+  __typename?: 'SwatchColour';
+  sys: Sys;
+  contentfulMetadata: ContentfulMetadata;
+  linkedFrom?: Maybe<SwatchColourLinkingCollections>;
+  name?: Maybe<Scalars['String']>;
+  colour?: Maybe<Scalars['String']>;
+  isDark?: Maybe<Scalars['Boolean']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatchColour) */
+export type SwatchColourLinkedFromArgs = {
+  allowedLocales?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatchColour) */
+export type SwatchColourNameArgs = {
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatchColour) */
+export type SwatchColourColourArgs = {
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/fq5pxympyusn/content_types/swatchColour) */
+export type SwatchColourIsDarkArgs = {
+  locale?: Maybe<Scalars['String']>;
+};
+
+export type SwatchColourCollection = {
+  __typename?: 'SwatchColourCollection';
+  total: Scalars['Int'];
+  skip: Scalars['Int'];
+  limit: Scalars['Int'];
+  items: Array<Maybe<SwatchColour>>;
+};
+
+export type SwatchColourFilter = {
+  sys?: Maybe<SysFilter>;
+  contentfulMetadata?: Maybe<ContentfulMetadataFilter>;
+  name_exists?: Maybe<Scalars['Boolean']>;
+  name?: Maybe<Scalars['String']>;
+  name_not?: Maybe<Scalars['String']>;
+  name_in?: Maybe<Array<Maybe<Scalars['String']>>>;
+  name_not_in?: Maybe<Array<Maybe<Scalars['String']>>>;
+  name_contains?: Maybe<Scalars['String']>;
+  name_not_contains?: Maybe<Scalars['String']>;
+  colour_exists?: Maybe<Scalars['Boolean']>;
+  colour?: Maybe<Scalars['String']>;
+  colour_not?: Maybe<Scalars['String']>;
+  colour_in?: Maybe<Array<Maybe<Scalars['String']>>>;
+  colour_not_in?: Maybe<Array<Maybe<Scalars['String']>>>;
+  colour_contains?: Maybe<Scalars['String']>;
+  colour_not_contains?: Maybe<Scalars['String']>;
+  isDark_exists?: Maybe<Scalars['Boolean']>;
+  isDark?: Maybe<Scalars['Boolean']>;
+  isDark_not?: Maybe<Scalars['Boolean']>;
+  OR?: Maybe<Array<Maybe<SwatchColourFilter>>>;
+  AND?: Maybe<Array<Maybe<SwatchColourFilter>>>;
+};
+
+export type SwatchColourLinkingCollections = {
+  __typename?: 'SwatchColourLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+};
+
+
+export type SwatchColourLinkingCollectionsEntryCollectionArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+export enum SwatchColourOrder {
+  NameAsc = 'name_ASC',
+  NameDesc = 'name_DESC',
+  ColourAsc = 'colour_ASC',
+  ColourDesc = 'colour_DESC',
+  IsDarkAsc = 'isDark_ASC',
+  IsDarkDesc = 'isDark_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
+export type SwatchFilter = {
+  sys?: Maybe<SysFilter>;
+  contentfulMetadata?: Maybe<ContentfulMetadataFilter>;
+  title_exists?: Maybe<Scalars['Boolean']>;
+  title?: Maybe<Scalars['String']>;
+  title_not?: Maybe<Scalars['String']>;
+  title_in?: Maybe<Array<Maybe<Scalars['String']>>>;
+  title_not_in?: Maybe<Array<Maybe<Scalars['String']>>>;
+  title_contains?: Maybe<Scalars['String']>;
+  title_not_contains?: Maybe<Scalars['String']>;
+  colourCollection_exists?: Maybe<Scalars['Boolean']>;
+  OR?: Maybe<Array<Maybe<SwatchFilter>>>;
+  AND?: Maybe<Array<Maybe<SwatchFilter>>>;
+};
+
+export type SwatchLinkingCollections = {
+  __typename?: 'SwatchLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+};
+
+
+export type SwatchLinkingCollectionsEntryCollectionArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+export enum SwatchOrder {
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+}
+
 export type Sys = {
   __typename?: 'Sys';
   id: Scalars['String'];
@@ -2519,13 +2734,13 @@ export type PageByPathQuery = (
               & { items: Array<Maybe<(
                 { __typename?: 'ApiField' }
                 & Pick<ApiField, 'name' | 'dataType' | 'defaultValue' | 'description' | 'required'>
-              ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' }>> }
+              ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' } | { __typename?: 'Swatch' } | { __typename?: 'SwatchColour' }>> }
             )>, apiReturnFieldCollection?: Maybe<(
               { __typename?: 'ApiTableApiReturnFieldCollection' }
               & { items: Array<Maybe<(
                 { __typename?: 'ApiField' }
                 & Pick<ApiField, 'name' | 'dataType' | 'defaultValue' | 'description' | 'required'>
-              ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' }>> }
+              ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' } | { __typename?: 'Swatch' } | { __typename?: 'SwatchColour' }>> }
             )> }
           ) | (
             { __typename: 'CodeBlock' }
@@ -2639,6 +2854,24 @@ export type PageByPathQuery = (
                       { __typename?: 'Sys' }
                       & Pick<Sys, 'id'>
                     ) }
+                  ) | (
+                    { __typename: 'Swatch' }
+                    & { colourCollection?: Maybe<(
+                      { __typename?: 'SwatchColourCollection' }
+                      & { items: Array<Maybe<(
+                        { __typename?: 'SwatchColour' }
+                        & Pick<SwatchColour, 'name' | 'colour' | 'isDark'>
+                      )>> }
+                    )>, sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'SwatchColour' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
                   )>>, inline: Array<Maybe<(
                     { __typename: 'ApiField' }
                     & { sys: (
@@ -2714,6 +2947,18 @@ export type PageByPathQuery = (
                     ) }
                   ) | (
                     { __typename: 'SimpleCard' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'Swatch' }
+                    & { sys: (
+                      { __typename?: 'Sys' }
+                      & Pick<Sys, 'id'>
+                    ) }
+                  ) | (
+                    { __typename: 'SwatchColour' }
                     & { sys: (
                       { __typename?: 'Sys' }
                       & Pick<Sys, 'id'>
@@ -2867,13 +3112,13 @@ export type SectionContentQuery = (
           & { items: Array<Maybe<(
             { __typename?: 'ApiField' }
             & Pick<ApiField, 'name' | 'dataType' | 'defaultValue' | 'description' | 'required'>
-          ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' }>> }
+          ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' } | { __typename?: 'Swatch' } | { __typename?: 'SwatchColour' }>> }
         )>, apiReturnFieldCollection?: Maybe<(
           { __typename?: 'ApiTableApiReturnFieldCollection' }
           & { items: Array<Maybe<(
             { __typename?: 'ApiField' }
             & Pick<ApiField, 'name' | 'dataType' | 'defaultValue' | 'description' | 'required'>
-          ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' }>> }
+          ) | { __typename?: 'ApiTable' } | { __typename?: 'CodeBlock' } | { __typename?: 'ContentBlock' } | { __typename?: 'Hero' } | { __typename?: 'Homepage' } | { __typename?: 'LiveExample' } | { __typename?: 'MarkdownTable' } | { __typename?: 'Navigation' } | { __typename?: 'NavigationElement' } | { __typename?: 'Page' } | { __typename?: 'Section' } | { __typename?: 'SimpleCard' } | { __typename?: 'Swatch' } | { __typename?: 'SwatchColour' }>> }
         )> }
       ) | (
         { __typename: 'CodeBlock' }

--- a/graphql/queries/PageByPath.graphql
+++ b/graphql/queries/PageByPath.graphql
@@ -60,6 +60,17 @@ query PageByPath($path: String!) {
                         ... on MarkdownTable {
                           markdown
                         }
+                        ... on Swatch {
+                          colourCollection(limit: 20) {
+                            items {
+                              ... on SwatchColour {
+                                name
+                                colour
+                                isDark
+                              }
+                            }
+                          }
+                        }
                       }
                       inline {
                         sys {


### PR DESCRIPTION
## Related issue
Closes #247 

## Overview
Adds the ability to display a colour swatch using a React component backed by the Contentful content model.

## Reason
> The colour swatches in the Styles/Colours section can only be displayed as images at present. There is no way to publish HTML. This means that the desktop and mobile experience of the docs site will be impaired.

## Work carried out
- [x] Add `Swatch`
- [x] Integrate with content model

## Screenshot
### React component
![Screenshot 2021-09-15 at 11 47 33](https://user-images.githubusercontent.com/56078793/133420116-5c95066a-0f10-411c-a9c0-93483b82d7bd.png)

### Integrated (sample data)
![Screenshot 2021-09-15 at 12 08 59](https://user-images.githubusercontent.com/56078793/133422955-c2b2a5f7-7d38-4959-846a-c36dbb37bdd3.png)