### PR TITLE
feat(ContentBlock): Use kebab-case

### DIFF
--- a/components/adapters/Docs/ContentBlockAdapter.tsx
+++ b/components/adapters/Docs/ContentBlockAdapter.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { selectors } from '@royalnavy/design-tokens'
-import camelCase from 'lodash/camelCase'
+import kebabCase from 'lodash/kebabCase'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 import { BLOCKS, INLINES } from '@contentful/rich-text-types'
 import { MarkdownTable } from '../../presenters/Docs/MarkdownTable'
@@ -133,7 +133,7 @@ function getRichTextRenderOptions(links) {
 
         return (
           <StyledH2
-            id={camelCase(h2Index + content.toString())}
+            id={kebabCase(h2Index + content.toString())}
             data-testid="content-block-h2"
           >
             <span>{h2Index}</span>

--- a/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
+++ b/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
@@ -154,6 +154,13 @@ describe('Docs/ContentBlockAdapter', () => {
         'Overview'
       )
     })
+
+    it('renders the h2 with the `id` attribute', () => {
+      expect(wrapper.getByTestId('content-block-h2')).toHaveAttribute(
+        'id',
+        '1-overview'
+      )
+    })
   })
 
   describe('with markdown table linked entry', () => {

--- a/cypress/specs/docs/components.spec.ts
+++ b/cypress/specs/docs/components.spec.ts
@@ -7,13 +7,13 @@ import { baseUrl } from '../../../cypress.json'
 import selectors from '../../selectors/docs'
 
 const sections = [
-  { title: 'Overview', link: '#1Overview' },
-  { title: 'Usage', link: '#2Usage' },
-  { title: 'Anatomy', link: '#3Anatomy' },
-  { title: 'Sizing & Spacing', link: '#4SizingSpacing' },
-  { title: 'Hierarchy & Placement', link: '#5HierarchyPlacement' },
-  { title: 'States', link: '#6States' },
-  { title: 'Variations', link: '#7Variations' },
+  { title: 'Overview', link: '#1-overview' },
+  { title: 'Usage', link: '#2-usage' },
+  { title: 'Anatomy', link: '#3-anatomy' },
+  { title: 'Sizing & Spacing', link: '#4-sizing-spacing' },
+  { title: 'Hierarchy & Placement', link: '#5-hierarchy-placement' },
+  { title: 'States', link: '#6-states' },
+  { title: 'Variations', link: '#7-variations' },
 ]
 
 describe('Docs Site: Components', () => {

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import groupBy from 'lodash/groupBy'
 import upperFirst from 'lodash/upperFirst'
-import camelCase from 'lodash/camelCase'
+import kebabCase from 'lodash/kebabCase'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -245,7 +245,7 @@ function renderOnThisPageItems(
 
   return h2Collection.map((item: Record<string, any>, index: number) => {
     const title = item?.content[0]?.value
-    const href = `#${camelCase(`${index + 1}${title}`)}`
+    const href = `#${kebabCase(`${index + 1}${title}`)}`
 
     return (
       <OnThisPageItem key={href} onClick={(_) => push(href)}>


### PR DESCRIPTION
## Related issue
Closes #92 

## Overview
Use dashes instead of camelCase for content section IDs.

## Reason
> more URL friendly and consistent with legacy URL structure

## Work carried out
- [x] Replace `camelCase`

## Screenshot
![Screenshot 2021-09-20 at 15 51 20](https://user-images.githubusercontent.com/56078793/134023499-ccf382b3-2cb1-4ca4-907b-4bb644460fe7.png)
