### PR TITLE
Styled table (and code block fix)

### DIFF
--- a/components/presenters/Docs/MarkdownTable/MarkdownTable.tsx
+++ b/components/presenters/Docs/MarkdownTable/MarkdownTable.tsx
@@ -1,13 +1,56 @@
 import React from 'react'
 import Markdown from 'markdown-to-jsx'
+import { selectors } from '@royalnavy/design-tokens'
 import styled from 'styled-components'
+
+const { color, mq, fontSize, spacing } = selectors
 
 interface MarkdownTableProps {
   children: string
 }
 
 const StyledMarkdownTable = styled(Markdown)`
-  // add styles
+  border-collapse: collapse;
+  margin: ${spacing('12')} 0;
+  padding: 0;
+  width: 100%;
+  table-layout: fixed;
+  border-top: 1px solid ${color('neutral', '100')};
+  border-bottom: 1px solid ${color('neutral', '100')};
+  border-right: 1px solid ${color('neutral', '100')};
+
+  tr:nth-child(odd) {
+    background-color: ${color('neutral', '000')};
+  }
+
+  th,
+  td {
+    padding: ${spacing('6')} ${spacing('10')};
+    text-align: left;
+    white-space: nowrap;
+    font-size: ${fontSize('base')};
+    color: ${color('neutral', '400')};
+    border-left: 1px solid ${color('neutral', '100')};
+  }
+
+  th {
+    font-size: ${fontSize('m')};
+    background-color: ${color('neutral', 'white')};
+    color: ${color('neutral', '500')};
+    border-bottom: 2px solid ${color('neutral', '100')};
+  }
+
+  code {
+    background-color: ${color('neutral', '500')};
+    color: ${color('neutral', 'white')};
+    padding: ${spacing('1')} ${spacing('3')} ${spacing('2')};
+    line-height: 1;
+    margin-right: ${spacing('4')};
+  }
+
+  ${mq({ gte: 'm' })`
+
+  `}
 `
 
 export const MarkdownTable: React.FC<MarkdownTableProps> = (props) => (

--- a/components/presenters/Framework/CodeBlock/partials/StyledCodeBlock.tsx
+++ b/components/presenters/Framework/CodeBlock/partials/StyledCodeBlock.tsx
@@ -5,27 +5,7 @@ const { color, spacing, mq } = selectors
 
 export const StyledCodeBlock = styled.div`
   background-color: ${color('neutral', '700')};
-  padding-top: ${spacing('8')};
   width: 100%;
-
-  ${mq({ gte: 'xl' })`
-    border-top: 4px solid ${color('neutral', '600')};
-    width: 50%;
-    padding-top: ${spacing('15')};
-    padding-bottom: ${spacing('13')};
-  `}
-
-  @media only screen and (min-width: 1900px) {
-    width: calc(100% - 900px);
-  }
-
-  &:empty {
-    display: none;
-
-    ${mq({ gte: 'xl' })`
-      display: block;
-    `}
-  }
 
   pre,
   pre[class*='language-'] {


### PR DESCRIPTION
This PR styles the markdown table.

The 2nd commit deletes extra code from the `StyledCodeBlock` styles, which were causing the code block to not span full width.