### PR TITLE
Fix `CodeBlock` to be block rather inline in Contentful

### DIFF
--- a/components/adapters/Docs/ContentBlockAdapter.tsx
+++ b/components/adapters/Docs/ContentBlockAdapter.tsx
@@ -104,11 +104,18 @@ function getRichTextRenderOptions(links) {
         )
       },
       [BLOCKS.EMBEDDED_ENTRY]: (node) => {
-        const entryBlockMap = getEntryMap<MarkdownTableType | SwatchType>(
-          links,
-          'entries'
-        )
+        const entryBlockMap = getEntryMap<
+          CodeBlockType | MarkdownTableType | SwatchType
+        >(links, 'entries')
         const entry = entryBlockMap.get(node.data.target.sys.id)
+
+        if (entry.__typename === 'CodeBlock') {
+          return (
+            <CodeBlock language="scss">
+              {(entry as CodeBlockType).sourceCode}
+            </CodeBlock>
+          )
+        }
 
         if (entry.__typename === 'MarkdownTable') {
           return (
@@ -156,20 +163,6 @@ function getRichTextRenderOptions(links) {
         const hyperlink = hyperlinksMap.get(node.data.target.sys.id)
 
         return <a href={hyperlink.url}>{node.content[0].value}</a>
-      },
-      [INLINES.EMBEDDED_ENTRY]: (node) => {
-        const entryInlineMap = getEntryMap<CodeBlockType>(
-          links,
-          'entries',
-          'inline'
-        )
-        const entry = entryInlineMap.get(node.data.target.sys.id)
-
-        if (entry.__typename === 'CodeBlock') {
-          return <CodeBlock language="scss">{entry.sourceCode}</CodeBlock>
-        }
-
-        return null
       },
     },
   }

--- a/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
+++ b/components/adapters/Docs/__tests__/ContentBlockAdapter.test.tsx
@@ -226,7 +226,7 @@ describe('Docs/ContentBlockAdapter', () => {
             data: {},
             content: [
               {
-                nodeType: 'embedded-entry-inline',
+                nodeType: 'embedded-entry-block',
                 content: [],
                 data: {
                   target: {
@@ -242,7 +242,7 @@ describe('Docs/ContentBlockAdapter', () => {
           },
           links: {
             entries: {
-              inline: [
+              block: [
                 {
                   sys: {
                     id: '47DP1urOOAdvdXaCGeheqZ',

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -2796,6 +2796,7 @@ export type PageByPathQuery = (
                     ) }
                   ) | (
                     { __typename: 'CodeBlock' }
+                    & Pick<CodeBlock, 'sourceCode'>
                     & { sys: (
                       { __typename?: 'Sys' }
                       & Pick<Sys, 'id'>
@@ -2893,7 +2894,6 @@ export type PageByPathQuery = (
                     ) }
                   ) | (
                     { __typename: 'CodeBlock' }
-                    & Pick<CodeBlock, 'sourceCode'>
                     & { sys: (
                       { __typename?: 'Sys' }
                       & Pick<Sys, 'id'>

--- a/graphql/queries/PageByPath.graphql
+++ b/graphql/queries/PageByPath.graphql
@@ -77,15 +77,16 @@ query PageByPath($path: String!) {
                             }
                           }
                         }
+                        ... on CodeBlock {
+                          sourceCode
+                        }
                       }
                       inline {
                         sys {
                           id
                         }
                         __typename
-                        ... on CodeBlock {
-                          sourceCode
-                        }
+
                       }
                     }
                   }


### PR DESCRIPTION
## Related issue
Fixes #289 

## Overview
Changes `CodeBlock` content to be blocks rather than inline.

## Reason
There will be a requirement to display other assets as inline but block is the most appropriate for `CodeBlock`.

## Work carried out
- [x] Update query

## Screenshot
![Screenshot 2021-09-27 at 14 45 57](https://user-images.githubusercontent.com/56078793/134921426-1b05c96c-7dc4-49b0-b713-18d66055737c.png)

## Developer notes
- to test use `/tokens/breakpoints`, other content will be updated once approved