### PR TITLE
staging_fix(Masthead): Render different nav for mobile

### DIFF
--- a/components/presenters/Docs/Masthead/partials/StyledMastheadMenu.tsx
+++ b/components/presenters/Docs/Masthead/partials/StyledMastheadMenu.tsx
@@ -16,6 +16,11 @@ export const StyledMastheadMenu = styled.nav<StyledMastheadMenuProps>`
   height: 100vh;
   padding: ${spacing('6')} 0;
   box-shadow: ${shadow('3')};
+  overflow-y: scroll;
+
+  ${mq({ gte: 'm' })`
+    overflow-y: unset;
+  `}
 
   ol {
     padding: 0;

--- a/cypress/specs/docs/components.spec.ts
+++ b/cypress/specs/docs/components.spec.ts
@@ -27,11 +27,6 @@ describe('Docs Site: Components', () => {
       cy.visit('/components/alert')
     })
 
-    it('Reference navigation item should not redirect user', () => {
-      cy.get('a').contains('Reference').click()
-      cy.url().should('eq', `${baseUrl}/components/alert#`)
-    })
-
     it('should render the page title', () => {
       cy.get(selectors.layout.h1).should('have.text', 'Alert')
     })
@@ -153,70 +148,4 @@ describe('Docs Site: Components', () => {
       })
     })
   })
-})
-
-describe('Docs Site: Homepage', () => {
-  describe('when browsing on desktop', () => {
-    before(() => {
-      // Block newrelic.js due to issues with Cypress networking
-      cy.intercept('**/newrelic.js', (req) => {
-        req.reply("console.log('Fake New Relic script loaded');")
-      })
-
-      cy.visit('/')
-    })
-
-    it('should not render a sub menu for top level navigation items without children', () => {
-      cy.get('a').contains('Help').siblings('button').should('not.exist')
-    })
-  })
-
-  describe(
-    'when browsing on mobile',
-    {
-      viewportHeight: 1000,
-      viewportWidth: 500,
-    },
-    () => {
-      before(() => {
-        // Block newrelic.js due to issues with Cypress networking
-        cy.intercept('**/newrelic.js', (req) => {
-          req.reply("console.log('Fake New Relic script loaded');")
-        })
-
-        cy.visit('/')
-      })
-
-      describe('when the mobile navigation is opened', () => {
-        it('should open the mobile navigation', () => {
-          cy.get(selectors.layout.mastheadToggleButton).click()
-          cy.get(selectors.layout.mastheadMenuExpandButton).should('be.visible')
-        })
-
-        describe('and the first sub menu group is expanded', () => {
-          it('should expand the relevant sub menu', () => {
-            cy.get(selectors.layout.mastheadMenuExpandButton).eq(0).click()
-            cy.get('a').contains('Get started').should('be.visible')
-            cy.get('a').contains('Tokens').should('not.exist')
-          })
-
-          describe('and the second sub menu group is expanded', () => {
-            it('should expand the relevant sub menu', () => {
-              cy.get(selectors.layout.mastheadMenuExpandButton).eq(1).click()
-              cy.get('a').contains('Get started').should('be.visible')
-              cy.get('a').contains('Tokens').should('be.visible')
-            })
-
-            describe('and the first sub menu group is collapsed', () => {
-              it('should collapse the relevant sub menu', () => {
-                cy.get(selectors.layout.mastheadMenuExpandButton).eq(0).click()
-                cy.get('a').contains('Get started').should('not.exist')
-                cy.get('a').contains('Tokens').should('be.visible')
-              })
-            })
-          })
-        })
-      })
-    }
-  )
 })

--- a/cypress/specs/docs/homepage.spec.ts
+++ b/cypress/specs/docs/homepage.spec.ts
@@ -1,0 +1,71 @@
+/* eslint-disable jest/expect-expect */
+import { describe, cy, it, before } from 'local-cypress'
+
+// eslint-disable-next-line import/extensions
+import selectors from '../../selectors/docs'
+
+describe('Docs Site: Homepage', () => {
+  describe('when browsing on desktop', () => {
+    before(() => {
+      // Block newrelic.js due to issues with Cypress networking
+      cy.intercept('**/newrelic.js', (req) => {
+        req.reply("console.log('Fake New Relic script loaded');")
+      })
+
+      cy.visit('/')
+    })
+
+    it('should not render a sub menu for top level navigation items without children', () => {
+      cy.get('a').contains('Help').siblings('button').should('not.exist')
+    })
+  })
+
+  describe(
+    'when browsing on mobile',
+    {
+      viewportHeight: 1000,
+      viewportWidth: 500,
+    },
+    () => {
+      before(() => {
+        // Block newrelic.js due to issues with Cypress networking
+        cy.intercept('**/newrelic.js', (req) => {
+          req.reply("console.log('Fake New Relic script loaded');")
+        })
+
+        cy.visit('/')
+      })
+
+      describe('when the mobile navigation is opened', () => {
+        it('should open the mobile navigation', () => {
+          cy.get(selectors.layout.mastheadToggleButton).click()
+          cy.get(selectors.layout.mastheadMenuExpandButton).should('be.visible')
+        })
+
+        describe('and the first sub menu group is expanded', () => {
+          it('should expand the relevant sub menu', () => {
+            cy.get(selectors.layout.mastheadMenuExpandButton).eq(0).click()
+            cy.get('a').contains('Get started').should('be.visible')
+            cy.get('a').contains('Alert').should('not.exist')
+          })
+
+          describe('and the second sub menu group is expanded', () => {
+            it('should expand the relevant sub menu', () => {
+              cy.get(selectors.layout.mastheadMenuExpandButton).eq(1).click()
+              cy.get('a').contains('Get started').should('be.visible')
+              cy.get('a').contains('Alert').should('be.visible')
+            })
+
+            describe('and the first sub menu group is collapsed', () => {
+              it('should collapse the relevant sub menu', () => {
+                cy.get(selectors.layout.mastheadMenuExpandButton).eq(0).click()
+                cy.get('a').contains('Get started').should('not.exist')
+                cy.get('a').contains('Alert').should('be.visible')
+              })
+            })
+          })
+        })
+      })
+    }
+  )
+})

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -1831,6 +1831,10 @@ export type Query = {
   __typename?: 'Query';
   asset?: Maybe<Asset>;
   assetCollection?: Maybe<AssetCollection>;
+  page?: Maybe<Page>;
+  pageCollection?: Maybe<PageCollection>;
+  navigationElement?: Maybe<NavigationElement>;
+  navigationElementCollection?: Maybe<NavigationElementCollection>;
   swatchColour?: Maybe<SwatchColour>;
   swatchColourCollection?: Maybe<SwatchColourCollection>;
   swatch?: Maybe<Swatch>;
@@ -1841,10 +1845,6 @@ export type Query = {
   simpleCardCollection?: Maybe<SimpleCardCollection>;
   homepage?: Maybe<Homepage>;
   homepageCollection?: Maybe<HomepageCollection>;
-  page?: Maybe<Page>;
-  pageCollection?: Maybe<PageCollection>;
-  navigationElement?: Maybe<NavigationElement>;
-  navigationElementCollection?: Maybe<NavigationElementCollection>;
   navigation?: Maybe<Navigation>;
   navigationCollection?: Maybe<NavigationCollection>;
   apiField?: Maybe<ApiField>;
@@ -1879,6 +1879,40 @@ export type QueryAssetCollectionArgs = {
   locale?: Maybe<Scalars['String']>;
   where?: Maybe<AssetFilter>;
   order?: Maybe<Array<Maybe<AssetOrder>>>;
+};
+
+
+export type QueryPageArgs = {
+  id: Scalars['String'];
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+export type QueryPageCollectionArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+  where?: Maybe<PageFilter>;
+  order?: Maybe<Array<Maybe<PageOrder>>>;
+};
+
+
+export type QueryNavigationElementArgs = {
+  id: Scalars['String'];
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+export type QueryNavigationElementCollectionArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
+  locale?: Maybe<Scalars['String']>;
+  where?: Maybe<NavigationElementFilter>;
+  order?: Maybe<Array<Maybe<NavigationElementOrder>>>;
 };
 
 
@@ -1964,40 +1998,6 @@ export type QueryHomepageCollectionArgs = {
   locale?: Maybe<Scalars['String']>;
   where?: Maybe<HomepageFilter>;
   order?: Maybe<Array<Maybe<HomepageOrder>>>;
-};
-
-
-export type QueryPageArgs = {
-  id: Scalars['String'];
-  preview?: Maybe<Scalars['Boolean']>;
-  locale?: Maybe<Scalars['String']>;
-};
-
-
-export type QueryPageCollectionArgs = {
-  skip?: Maybe<Scalars['Int']>;
-  limit?: Maybe<Scalars['Int']>;
-  preview?: Maybe<Scalars['Boolean']>;
-  locale?: Maybe<Scalars['String']>;
-  where?: Maybe<PageFilter>;
-  order?: Maybe<Array<Maybe<PageOrder>>>;
-};
-
-
-export type QueryNavigationElementArgs = {
-  id: Scalars['String'];
-  preview?: Maybe<Scalars['Boolean']>;
-  locale?: Maybe<Scalars['String']>;
-};
-
-
-export type QueryNavigationElementCollectionArgs = {
-  skip?: Maybe<Scalars['Int']>;
-  limit?: Maybe<Scalars['Int']>;
-  preview?: Maybe<Scalars['Boolean']>;
-  locale?: Maybe<Scalars['String']>;
-  where?: Maybe<NavigationElementFilter>;
-  order?: Maybe<Array<Maybe<NavigationElementOrder>>>;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "prismjs": "^1.24.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-responsive": "^9.0.0-beta.4",
     "styled-components": "^5.3.0"
   },
   "devDependencies": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useMediaQuery } from 'react-responsive'
 import styled from 'styled-components'
 import Link from 'next/link'
 import { GetStaticProps } from 'next'
@@ -40,6 +41,7 @@ import { StyledCard } from '../components/presenters/Docs/Card/partials/StyledCa
 
 export interface HomeProps {
   desktopNavigation: NavigationType
+  mobileNavigation: NavigationType
   pageData: HomepageType
 }
 
@@ -68,22 +70,36 @@ async function fetchDesktopNavigation(): Promise<NavigationType> {
 }
 
 /**
+ * Fetch mobile navigation from Contentful
+ *
+ */
+async function fetchMobileNavigation(): Promise<NavigationType> {
+  const { navigation } = await contentful(NAVIGATION_BY_ID_QUERY, {
+    id: '3tE4icMED8H3oRTFAQHeCr',
+  })
+
+  return navigation
+}
+
+/**
  * Fetch data from Contentful for static site generation (SSG)
  *
  */
 export const getStaticProps: GetStaticProps = async (context) => {
   const desktopNavigation = await fetchDesktopNavigation()
+  const mobileNavigation = await fetchMobileNavigation()
   const pageData = await fetchPageData()
 
   return {
     props: {
       desktopNavigation,
+      mobileNavigation,
       pageData,
     },
   }
 }
 
-const { color, mq, spacing } = selectors
+const { color, mq, spacing, breakpoint } = selectors
 
 const StyledDollar = styled.span`
   font-weight: 600;
@@ -169,7 +185,11 @@ const StyledButtonGroup = styled.div`
   }
 `
 
-export const Home: React.FC<HomeProps> = ({ desktopNavigation, pageData }) => {
+export const Home: React.FC<HomeProps> = ({
+  desktopNavigation,
+  mobileNavigation,
+  pageData,
+}) => {
   const { version } = useDesignSystemVersion()
   const {
     heroHeading,
@@ -201,10 +221,16 @@ export const Home: React.FC<HomeProps> = ({ desktopNavigation, pageData }) => {
     </PageBanner>
   )
 
+  const isTabletOrMobile = useMediaQuery({
+    query: `(max-width: ${breakpoint('m').breakpoint})`,
+  })
+
+  const navigation = isTabletOrMobile ? mobileNavigation : desktopNavigation
+
   const masthead = (
     <Masthead version={version}>
       <MastheadMenu>
-        {desktopNavigation.childrenCollection.items.map(
+        {navigation.childrenCollection.items.map(
           ({
             title: parentTitle,
             path: parentPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14162,6 +14162,16 @@ react-responsive@^8.0.3:
     prop-types "^15.6.1"
     shallow-equal "^1.1.0"
 
+react-responsive@^9.0.0-beta.4:
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-9.0.0-beta.4.tgz#90c1f1a4048971497ca9795068af6803eabc0ddb"
+  integrity sha512-jQSs5kIi38T39Ku98r8s75jM6JAaNEeVrHPHTrL2EYWuv8nusV3KRQcZZ4VlfwndIRedxmpb4T8FXA9ltlCFiw==
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.3.0"
+    prop-types "^15.6.1"
+    shallow-equal "^1.2.1"
+
 react-select@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.2.0.tgz#de9284700196f5f9b5277c5d850a9ce85f5c72fe"
@@ -15136,7 +15146,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-shallow-equal@^1.1.0:
+shallow-equal@^1.1.0, shallow-equal@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==


### PR DESCRIPTION
## Related issue

Closes #314

## Overview

Mobile should render a slightly different navigational structure.

## Reason

>There isn't a way of accessing nested Reference pages at mobile because the Sidebar is hidden.

## Work carried out

- [x] Render different navigation based on breakpoint

## Screenshot
<img width="612" alt="Screenshot 2021-09-27 at 12 53 34" src="https://user-images.githubusercontent.com/48086589/134903267-98c57a81-1441-484b-8fc6-23e161446923.png">
