### PR TITLE
Fix `OnThisPage` state not resetting when changing route

### DIFF
--- a/cypress/helpers.ts
+++ b/cypress/helpers.ts
@@ -1,0 +1,5 @@
+import hexRgb from 'hex-rgb'
+
+export function hexToRgb(color) {
+  return hexRgb(color, { format: 'css' }).split(' ').join(', ')
+}

--- a/cypress/specs/docs/components.spec.ts
+++ b/cypress/specs/docs/components.spec.ts
@@ -1,10 +1,14 @@
 /* eslint-disable jest/expect-expect */
 import { describe, cy, it, before, expect } from 'local-cypress'
+import { selectors as designTokensSelectors } from '@royalnavy/design-tokens'
 import { startCase } from 'lodash'
 
 // eslint-disable-next-line import/extensions
 import { baseUrl } from '../../../cypress.json'
 import selectors from '../../selectors/docs'
+import { hexToRgb } from '../../helpers'
+
+const { color } = designTokensSelectors
 
 const sections = [
   { title: 'Overview', link: '#1-overview' },
@@ -86,9 +90,41 @@ describe('Docs Site: Components', () => {
           cy.get(selectors.onThisPage.item).eq(index).click({ force: true })
         })
 
+        it('should set the `OnThisPage` item as active', () => {
+          cy.get(selectors.onThisPage.item)
+            .eq(index)
+            .should(
+              'have.css',
+              'border-left',
+              `4px solid ${hexToRgb(color('neutral', '400'))}`
+            )
+        })
+
         it('should navigate to the relevant sub-heading', () => {
           cy.get(selectors.contentBlock.h2).eq(index).should('be.visible')
           cy.url().should('eq', `${baseUrl}/components/alert${link}`)
+        })
+      })
+    })
+
+    describe('when the third `OnThisPage` item has been clicked', () => {
+      before(() => {
+        cy.get(selectors.onThisPage.item).eq(2).click({ force: true })
+      })
+
+      describe('and `Notifications` sidebar item is clicked', () => {
+        before(() => {
+          cy.get(selectors.sidebar.links).eq(2).click()
+        })
+
+        it('should set the `OnThisPage` first item as active', () => {
+          cy.get(selectors.onThisPage.item)
+            .eq(0)
+            .should(
+              'have.css',
+              'border-left',
+              `4px solid ${hexToRgb(color('neutral', '400'))}`
+            )
         })
       })
     })

--- a/graphql/index.ts
+++ b/graphql/index.ts
@@ -2720,7 +2720,10 @@ export type PageByPathQuery = (
       )>, page?: Maybe<(
         { __typename?: 'Page' }
         & Pick<Page, 'title'>
-        & { sectionCollection?: Maybe<(
+        & { sys: (
+          { __typename?: 'Sys' }
+          & Pick<Sys, 'id'>
+        ), sectionCollection?: Maybe<(
           { __typename?: 'PageSectionCollection' }
           & { items: Array<Maybe<(
             { __typename: 'ApiTable' }

--- a/graphql/queries/PageByPath.graphql
+++ b/graphql/queries/PageByPath.graphql
@@ -1,5 +1,5 @@
 query PageByPath($path: String!) {
-  navigationElementCollection(where: { path: $path }, limit: 1) {
+  navigationElementCollection(where: {path: $path}, limit: 1) {
     items {
       title
       path
@@ -19,6 +19,9 @@ query PageByPath($path: String!) {
       }
       page {
         ... on Page {
+          sys {
+            id
+          }
           title
           sectionCollection(limit: 10) {
             items {

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -135,6 +135,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
       parentPage,
       desktopNavigation,
       mobileNavigation,
+      key: page.sys.id,
       childrenCollection: parentPage?.childrenCollection?.items || [],
     },
   }


### PR DESCRIPTION
## Related issue
Closes #300 

## Overview
Change adds a `key` so that the `Component` updates and resets state when the path changes.

## Reason
> "On this page" highlights the position of the previously selected heading. 

## Work carried out
- [x] Fix issue with test

## Developer notes
- https://github.com/vercel/next.js/issues/9992#issuecomment-615402511
